### PR TITLE
fix: Add missing #include <algorithm>.

### DIFF
--- a/src/Core/RoomInternalState.cpp
+++ b/src/Core/RoomInternalState.cpp
@@ -18,6 +18,7 @@
 
 #include <cmath>
 #include <numeric>
+#include <algorithm>
 
 namespace SparkyStudios::Audio::Amplitude
 {

--- a/src/DSP/AudioConverter.cpp
+++ b/src/DSP/AudioConverter.cpp
@@ -16,6 +16,8 @@
 
 #include <Utils/Utils.h>
 
+#include <algorithm>
+
 namespace SparkyStudios::Audio::Amplitude
 {
     AudioConverter::AudioConverter()

--- a/src/DSP/Delay.cpp
+++ b/src/DSP/Delay.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <ranges>
 
 #include <DSP/Delay.h>

--- a/src/DSP/Resamplers/DefaultResampler.cpp
+++ b/src/DSP/Resamplers/DefaultResampler.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <numeric>
 
 #include <SparkyStudios/Audio/Amplitude/Math/Utils.h>


### PR DESCRIPTION
`#include <algorithm>` is needed to build the SDK on Linux (using Clang 20.1.3 and libstdc++ 15.1.1 on Fedora 42). This is due to the use of `std::copy_n(...)`.