### PR TITLE
Instanced rendering

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -41,19 +41,36 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Suggestions for improvements
-            - Security concerns
-            - Test coverage
+            Please perform a comprehensive code review of this pull request and provide detailed feedback.
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            Review Focus Areas:
+            - Code quality and adherence to best practices (see CLAUDE.md for project conventions)
+            - Potential bugs, logic errors, or edge cases
+            - Performance considerations and optimization opportunities
+            - Security vulnerabilities (OWASP top 10, common CVEs)
+            - Memory management and resource leaks
+            - Thread safety and concurrency issues
+            - Test coverage and missing test cases
+            - Documentation completeness
+            - API design and usability
 
-            Use the GitHub MCP tools to create a proper PR review with comments.
-            You can use mcp__github__create_pending_pull_request_review to start a review
-            and mcp__github__submit_pull_request_review to submit it as a COMMENT (not APPROVE).
+            Review Guidelines:
+            1. Read the CLAUDE.md file to understand project-specific conventions (C++20, naming, formatting)
+            2. Examine all changed files thoroughly
+            3. Provide constructive, specific feedback with file:line references
+            4. Use confidence levels for issues (critical, moderate, suggestion)
+            5. Focus on significant issues rather than minor style nitpicks
+
+            Output Format:
+            - Create a GitHub PR review using the MCP tools
+            - Group feedback by severity (critical issues first)
+            - Include code snippets showing the issue and suggested fix when applicable
+            - Be professional, constructive, and helpful
+
+            IMPORTANT: Use the GitHub MCP tools to create and publish your review:
+            1. Use mcp__github__create_pending_pull_request_review to start a review
+            2. Add review comments for each issue found
+            3. Use mcp__github__submit_pull_request_review to publish as a COMMENT (not APPROVE or REQUEST_CHANGES)
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "mcp__github__create_pending_pull_request_review,mcp__github__submit_pull_request_review,Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "mcp__github__create_pending_pull_request_review,mcp__github__create_pull_request_review_comment,mcp__github__submit_pull_request_review,Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr files:*),Bash(gh api:*)"'

--- a/include/SparkyStudios/Audio/Amplitude/Core/Common/Constants.h
+++ b/include/SparkyStudios/Audio/Amplitude/Core/Common/Constants.h
@@ -176,6 +176,13 @@ namespace SparkyStudios::Audio::Amplitude
      * @ingroup core
      */
     constexpr AmReal32 kHighCutoffFrequencies[kAmAirAbsorptionBandCount] = { 800.0f, 8000.0f, 22000.0f };
+
+    /**
+     * @brief The maximum number of channel instances supported per channel.
+     *
+     * @ingroup core
+     */
+    constexpr AmSize kAmMaxChannelInstances = 1024;
 } // namespace SparkyStudios::Audio::Amplitude
 
 #endif // _AM_CORE_COMMON_CONSTANTS_H

--- a/include/SparkyStudios/Audio/Amplitude/Core/Common/Types.h
+++ b/include/SparkyStudios/Audio/Amplitude/Core/Common/Types.h
@@ -43,6 +43,7 @@ namespace SparkyStudios::Audio::Amplitude
     typedef AmObjectID          AmEntityID;
     typedef AmObjectID          AmListenerID;
     typedef AmObjectID          AmChannelID;
+    typedef AmObjectID          AmChannelInstanceID;
     typedef AmObjectID          AmEventID;
     typedef AmObjectID          AmPipelineID;
     typedef AmObjectID          AmAttenuationID;

--- a/include/SparkyStudios/Audio/Amplitude/Core/Playback/Channel.h
+++ b/include/SparkyStudios/Audio/Amplitude/Core/Playback/Channel.h
@@ -21,6 +21,7 @@
 #include <SparkyStudios/Audio/Amplitude/Core/Entity.h>
 #include <SparkyStudios/Audio/Amplitude/Core/Listener.h>
 #include <SparkyStudios/Audio/Amplitude/Core/Playback/ChannelEventListener.h>
+#include <SparkyStudios/Audio/Amplitude/Core/Playback/ChannelInstance.h>
 #include <SparkyStudios/Audio/Amplitude/Core/Room.h>
 
 namespace SparkyStudios::Audio::Amplitude
@@ -290,6 +291,98 @@ namespace SparkyStudios::Audio::Amplitude
          * @see ChannelEventCallback
          */
         void On(eChannelEvent event, ChannelEventCallback callback, void* userData = nullptr) const;
+
+        /**
+         * @brief Enables multi-position mode for this channel.
+         *
+         * When enabled, this channel can have multiple position instances, allowing
+         * the same sound to be perceived from multiple locations simultaneously.
+         *
+         * @param[in] mode The instance mode.
+         *
+         * @note Must be called before adding instances. The mode cannot be changed
+         * while instancing is already enabled.
+         *
+         * @see eChannelInstanceMode
+         * @see AddInstance
+         */
+        void EnableInstancing(eChannelInstanceMode mode) const;
+
+        /**
+         * @brief Disables multi-position mode, reverting to single-position behavior.
+         *
+         * All existing instances will be removed when instancing is disabled.
+         */
+        void DisableInstancing() const;
+
+        /**
+         * @brief Checks if multi-position instancing is enabled.
+         *
+         * @return @c true if instancing is enabled, @c false otherwise.
+         */
+        [[nodiscard]] bool IsInstancingEnabled() const;
+
+        /**
+         * @brief Gets the instancing mode.
+         *
+         * @return The current instancing mode.
+         *
+         * @see eChannelInstanceMode
+         */
+        [[nodiscard]] eChannelInstanceMode GetInstancingMode() const;
+
+        /**
+         * @brief Adds a new instance at the specified world position.
+         *
+         * Creates a new position instance for this channel. In Blended mode, all instances
+         * share the same playback cursor. In Separate mode, each instance has an independent
+         * cursor starting from the current playback position.
+         *
+         * @param[in] location The world position for the new instance.
+         *
+         * @return The created ChannelInstance handle.
+         *
+         * @note Instancing must be enabled before adding instances.
+         *
+         * @see EnableInstancing
+         * @see ChannelInstance
+         */
+        [[nodiscard]] ChannelInstance AddInstance(const AmVector3& location) const;
+
+        /**
+         * @brief Removes an instance by ID.
+         *
+         * @param[in] instanceId The ID of the instance to remove.
+         *
+         * @see ChannelInstance::GetId
+         */
+        void RemoveInstance(AmChannelInstanceID instanceId) const;
+
+        /**
+         * @brief Removes all instances.
+         *
+         * After calling this, the channel will have no position instances.
+         * Instancing will still be enabled with the same mode.
+         */
+        void ClearInstances() const;
+
+        /**
+         * @brief Gets an instance by ID.
+         *
+         * @param[in] instanceId The ID of the instance to retrieve.
+         *
+         * @return The ChannelInstance handle, or an invalid instance if not found.
+         *
+         * @see ChannelInstance::Valid
+         */
+        [[nodiscard]] ChannelInstance GetInstance(AmChannelInstanceID instanceId) const;
+
+        /**
+         * @brief Gets the number of active instances.
+         *
+         * @return The number of position instances.
+         */
+        [[nodiscard]] AmSize GetInstanceCount() const;
 
     private:
         /**

--- a/include/SparkyStudios/Audio/Amplitude/Core/Playback/ChannelInstance.h
+++ b/include/SparkyStudios/Audio/Amplitude/Core/Playback/ChannelInstance.h
@@ -1,0 +1,198 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifndef _AM_CORE_PLAYBACK_CHANNEL_INSTANCE_H
+#define _AM_CORE_PLAYBACK_CHANNEL_INSTANCE_H
+
+#include <SparkyStudios/Audio/Amplitude/Core/Common.h>
+#include <SparkyStudios/Audio/Amplitude/Core/Room.h>
+
+namespace SparkyStudios::Audio::Amplitude
+{
+    class ChannelInstanceInternalState;
+
+    /**
+     * @brief Defines how channel instances share audio data.
+     *
+     * This determines the playback behavior when a channel has multiple position instances.
+     *
+     * @ingroup engine
+     */
+    enum eChannelInstanceMode : AmUInt8
+    {
+        /**
+         * @brief All instances share the same playback cursor.
+         *
+         * Sound is perceived from multiple points with weighted-blend attenuation.
+         * Use this mode for continuous, ambient sounds that should be perceived as
+         * coming from multiple locations simultaneously.
+         *
+         * @par Example
+         * A river heard from multiple points along its path.
+         */
+        eChannelInstanceMode_Blended = 0,
+
+        /**
+         * @brief Instances share decoded audio data but have independent cursors.
+         *
+         * Each instance plays the same sound but with independent timing.
+         * Use this mode for sounds that should play independently at different locations,
+         * with natural variation in their timing.
+         *
+         * @par Example
+         * Multiple torches with the same fire sound but unsynchronized.
+         */
+        eChannelInstanceMode_Separate = 1,
+    };
+
+    /**
+     * @brief Represents a single position instance within a multi-position channel.
+     *
+     * A @c ChannelInstance stores per-position spatialization data including world location,
+     * per-instance room/environment associations, and instance-specific attenuation weights.
+     *
+     * Channel instances enable a single sound channel to emit from multiple world positions
+     * simultaneously, similar to instanced rendering in graphics where one mesh is rendered
+     * at multiple transforms.
+     *
+     * @note The @c ChannelInstance class is a lightweight wrapper around the internal
+     * @c ChannelInstanceInternalState class.
+     *
+     * @see Channel::AddInstance
+     * @see eChannelInstanceMode
+     *
+     * @ingroup engine
+     */
+    class AM_API_PUBLIC ChannelInstance
+    {
+    public:
+        /**
+         * @brief Creates an uninitialized channel instance.
+         *
+         * @note An uninitialized channel instance cannot have its data set or queried.
+         */
+        ChannelInstance();
+
+        /**
+         * @brief Creates a wrapper instance over the provided state.
+         *
+         * @param[in] state The internal state to wrap.
+         *
+         * @warning This constructor is for internal usage only.
+         */
+        explicit ChannelInstance(ChannelInstanceInternalState* state);
+
+        /**
+         * @brief Uninitializes this channel instance.
+         *
+         * @note This does not remove the instance from its parent channel, it just
+         * removes this reference to the internal state.
+         *
+         * @note To completely remove the instance, use the @c Channel::RemoveInstance method.
+         */
+        void Clear();
+
+        /**
+         * @brief Checks whether this channel instance has been initialized.
+         *
+         * @return @c true if this instance has been initialized with a valid state, @c false otherwise.
+         */
+        [[nodiscard]] bool Valid() const;
+
+        /**
+         * @brief Gets the unique ID of this instance within its parent channel.
+         *
+         * @return The instance's unique ID.
+         */
+        [[nodiscard]] AmChannelInstanceID GetId() const;
+
+        /**
+         * @brief Gets the world location of this instance.
+         *
+         * @return The world-space position of this instance.
+         */
+        [[nodiscard]] const AmVector3& GetLocation() const;
+
+        /**
+         * @brief Sets the world location of this instance.
+         *
+         * @param[in] location The new world-space position.
+         */
+        void SetLocation(const AmVector3& location) const;
+
+        /**
+         * @brief Gets the room associated with this instance.
+         *
+         * The room is used for per-instance environmental effects such as
+         * early reflections and reverberation.
+         *
+         * @return The room associated with this instance, or an uninitialized Room if none.
+         */
+        [[nodiscard]] Room GetRoom() const;
+
+        /**
+         * @brief Sets the room associated with this instance.
+         *
+         * Setting a room enables per-instance environmental effects. Each instance
+         * can be in a different room, allowing for spatially-accurate reverb and reflections.
+         *
+         * @param[in] room The room to associate with this instance.
+         */
+        void SetRoom(const Room& room) const;
+
+        /**
+         * @brief Gets the attenuation weight for blended mode.
+         *
+         * The weight determines how much this instance contributes to the final
+         * blended output. Higher weights result in more contribution from this instance.
+         *
+         * @note This value is primarily used in @c eChannelInstanceMode_Blended mode.
+         * In @c eChannelInstanceMode_Separate mode, each instance plays independently.
+         *
+         * @return The weight value (default is 1.0).
+         */
+        [[nodiscard]] AmReal32 GetWeight() const;
+
+        /**
+         * @brief Sets the attenuation weight for blended mode.
+         *
+         * @param[in] weight The weight (0.0 to any positive value). Values are clamped to be non-negative.
+         * Higher values result in more contribution from this instance.
+         *
+         * @note This value is primarily used in @c eChannelInstanceMode_Blended mode.
+         */
+        void SetWeight(AmReal32 weight) const;
+
+        /**
+         * @brief Gets the internal state of the channel instance.
+         *
+         * @return The internal state.
+         *
+         * @warning This method is for internal usage only.
+         */
+        [[nodiscard]] ChannelInstanceInternalState* GetState() const;
+
+    private:
+        /**
+         * @brief The internal state of the channel instance.
+         *
+         * @internal
+         */
+        ChannelInstanceInternalState* _state;
+    };
+} // namespace SparkyStudios::Audio::Amplitude
+
+#endif // _AM_CORE_PLAYBACK_CHANNEL_INSTANCE_H

--- a/include/SparkyStudios/Audio/Amplitude/Mixer/Amplimix.h
+++ b/include/SparkyStudios/Audio/Amplitude/Mixer/Amplimix.h
@@ -22,6 +22,7 @@
 #include <SparkyStudios/Audio/Amplitude/Core/Listener.h>
 #include <SparkyStudios/Audio/Amplitude/Core/Playback/Bus.h>
 #include <SparkyStudios/Audio/Amplitude/Core/Playback/Channel.h>
+#include <SparkyStudios/Audio/Amplitude/Core/Playback/ChannelInstance.h>
 #include <SparkyStudios/Audio/Amplitude/Core/Room.h>
 #include <SparkyStudios/Audio/Amplitude/Sound/Attenuation.h>
 
@@ -285,6 +286,68 @@ namespace SparkyStudios::Audio::Amplitude
          * @return The current sample rate of the audio data in the layer.
          */
         virtual AmUInt32 GetSampleRate() const = 0;
+
+        /**
+         * @brief Checks if this layer is processing a multi-position channel.
+         *
+         * @return @c true if the channel has multiple position instances, @c false otherwise.
+         */
+        [[nodiscard]] virtual bool IsMultiPosition() const = 0;
+
+        /**
+         * @brief Gets the instancing mode for multi-position channels.
+         *
+         * @return The instancing mode.
+         *
+         * @see eChannelInstanceMode
+         */
+        [[nodiscard]] virtual eChannelInstanceMode GetInstancingMode() const = 0;
+
+        /**
+         * @brief Gets the number of active position instances.
+         *
+         * @return The number of instances. Returns 0 if instancing is not enabled.
+         */
+        [[nodiscard]] virtual AmSize GetInstanceCount() const = 0;
+
+        /**
+         * @brief Gets the location of a specific instance.
+         *
+         * @param[in] index The instance index.
+         *
+         * @return The world-space location of the instance.
+         */
+        [[nodiscard]] virtual AmVector3 GetInstanceLocation(AmSize index) const = 0;
+
+        /**
+         * @brief Gets the room associated with a specific instance.
+         *
+         * @param[in] index The instance index.
+         *
+         * @return The room associated with the instance.
+         */
+        [[nodiscard]] virtual Room GetInstanceRoom(AmSize index) const = 0;
+
+        /**
+         * @brief Gets the weight of a specific instance (for Blended mode).
+         *
+         * @param[in] index The instance index.
+         *
+         * @return The weight value for the instance.
+         */
+        [[nodiscard]] virtual AmReal32 GetInstanceWeight(AmSize index) const = 0;
+
+        /**
+         * @brief Gets the computed attenuation gain for a specific instance.
+         *
+         * This value is pre-computed during the frame update based on the instance's
+         * position relative to the listener.
+         *
+         * @param[in] index The instance index.
+         *
+         * @return The computed gain value for the instance.
+         */
+        [[nodiscard]] virtual AmReal32 GetInstanceGain(AmSize index) const = 0;
     };
 
     /**

--- a/src/Core/Playback/Channel.cpp
+++ b/src/Core/Playback/Channel.cpp
@@ -199,4 +199,87 @@ namespace SparkyStudios::Audio::Amplitude
     {
         return _state->GetChannelStateId() == _stateId;
     }
+
+    void Channel::EnableInstancing(eChannelInstanceMode mode) const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        if (!IsValidStateId())
+            return;
+
+        _state->EnableInstancing(mode);
+    }
+
+    void Channel::DisableInstancing() const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        if (!IsValidStateId())
+            return;
+
+        _state->DisableInstancing();
+    }
+
+    bool Channel::IsInstancingEnabled() const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        if (!IsValidStateId())
+            return false;
+
+        return _state->IsInstancingEnabled();
+    }
+
+    eChannelInstanceMode Channel::GetInstancingMode() const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        if (!IsValidStateId())
+            return eChannelInstanceMode_Blended;
+
+        return _state->GetInstancingMode();
+    }
+
+    ChannelInstance Channel::AddInstance(const AmVector3& location) const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        if (!IsValidStateId())
+            return ChannelInstance();
+
+        ChannelInstanceInternalState* state = _state->AddInstance(location);
+        return ChannelInstance(state);
+    }
+
+    void Channel::RemoveInstance(AmChannelInstanceID instanceId) const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        if (!IsValidStateId())
+            return;
+
+        _state->RemoveInstance(instanceId);
+    }
+
+    void Channel::ClearInstances() const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        if (!IsValidStateId())
+            return;
+
+        _state->ClearInstances();
+    }
+
+    ChannelInstance Channel::GetInstance(AmChannelInstanceID instanceId) const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        if (!IsValidStateId())
+            return ChannelInstance();
+
+        ChannelInstanceInternalState* state = _state->GetInstance(instanceId);
+        return ChannelInstance(state);
+    }
+
+    AmSize Channel::GetInstanceCount() const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        if (!IsValidStateId())
+            return 0;
+
+        return _state->GetInstanceCount();
+    }
 } // namespace SparkyStudios::Audio::Amplitude

--- a/src/Core/Playback/ChannelInstance.cpp
+++ b/src/Core/Playback/ChannelInstance.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Core/Playback/ChannelInstance.h>
+
+#include <Core/Playback/ChannelInstanceInternalState.h>
+
+namespace SparkyStudios::Audio::Amplitude
+{
+    ChannelInstance::ChannelInstance()
+        : _state(nullptr)
+    {}
+
+    ChannelInstance::ChannelInstance(ChannelInstanceInternalState* state)
+        : _state(state)
+    {}
+
+    void ChannelInstance::Clear()
+    {
+        _state = nullptr;
+    }
+
+    bool ChannelInstance::Valid() const
+    {
+        return _state != nullptr && _state->GetId() != kAmInvalidObjectId && _state->instance_node.in_list();
+    }
+
+    AmChannelInstanceID ChannelInstance::GetId() const
+    {
+        return _state != nullptr ? _state->GetId() : kAmInvalidObjectId;
+    }
+
+    const AmVector3& ChannelInstance::GetLocation() const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        return _state->GetLocation();
+    }
+
+    void ChannelInstance::SetLocation(const AmVector3& location) const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        _state->SetLocation(location);
+    }
+
+    Room ChannelInstance::GetRoom() const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        return _state->GetRoom();
+    }
+
+    void ChannelInstance::SetRoom(const Room& room) const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        _state->SetRoom(room);
+    }
+
+    AmReal32 ChannelInstance::GetWeight() const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        return _state->GetWeight();
+    }
+
+    void ChannelInstance::SetWeight(AmReal32 weight) const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        _state->SetWeight(weight);
+    }
+
+    ChannelInstanceInternalState* ChannelInstance::GetState() const
+    {
+        return _state;
+    }
+} // namespace SparkyStudios::Audio::Amplitude

--- a/src/Core/Playback/ChannelInstanceInternalState.cpp
+++ b/src/Core/Playback/ChannelInstanceInternalState.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Core/Playback/ChannelInstanceInternalState.h>
+
+namespace SparkyStudios::Audio::Amplitude
+{
+    ChannelInstanceInternalState::ChannelInstanceInternalState()
+        : _instanceId(kAmInvalidObjectId)
+        , _parentChannel(nullptr)
+        , _location(kVector3Zero)
+        , _previousLocation(kVector3Zero)
+        , _room()
+        , _weight(1.0f)
+        , _cursor(0)
+        , _loopCount(0)
+        , _finished(false)
+        , _computedGain(1.0f)
+        , _pannedGain(kVector2One)
+        , _dopplerFactors()
+    {}
+
+    ChannelInstanceInternalState::ChannelInstanceInternalState(ChannelInternalState* parentChannel)
+        : _instanceId(kAmInvalidObjectId)
+        , _parentChannel(parentChannel)
+        , _location(kVector3Zero)
+        , _previousLocation(kVector3Zero)
+        , _room()
+        , _weight(1.0f)
+        , _cursor(0)
+        , _loopCount(0)
+        , _finished(false)
+        , _computedGain(1.0f)
+        , _pannedGain(kVector2One)
+        , _dopplerFactors()
+    {}
+
+    void ChannelInstanceInternalState::Reset()
+    {
+        _instanceId = kAmInvalidObjectId;
+        _location = kVector3Zero;
+        _previousLocation = kVector3Zero;
+        _room.Clear();
+        _weight = 1.0f;
+        _cursor = 0;
+        _loopCount = 0;
+        _finished = false;
+        _computedGain = 1.0f;
+        _pannedGain = kVector2One;
+        _dopplerFactors.clear();
+    }
+
+    void ChannelInstanceInternalState::SetRoom(const Room& room)
+    {
+        _room = room;
+    }
+
+    void ChannelInstanceInternalState::AdvanceCursor(AmUInt64 frames, AmUInt64 soundLength, bool loop)
+    {
+        if (_finished)
+            return;
+
+        _cursor += frames;
+
+        if (_cursor >= soundLength)
+        {
+            if (loop)
+            {
+                _cursor = _cursor % soundLength;
+                _loopCount++;
+            }
+            else
+            {
+                _cursor = soundLength;
+                _finished = true;
+            }
+        }
+    }
+
+    AmReal32 ChannelInstanceInternalState::GetDopplerFactor(AmListenerID listener) const
+    {
+        if (const auto it = _dopplerFactors.find(listener); it != _dopplerFactors.end())
+            return it->second;
+
+        return 1.0f;
+    }
+
+    void ChannelInstanceInternalState::SetDopplerFactor(AmListenerID listener, AmReal32 factor)
+    {
+        _dopplerFactors[listener] = factor;
+    }
+} // namespace SparkyStudios::Audio::Amplitude

--- a/src/Core/Playback/ChannelInstanceInternalState.h
+++ b/src/Core/Playback/ChannelInstanceInternalState.h
@@ -1,0 +1,301 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifndef _AM_IMPLEMENTATION_CORE_PLAYBACK_CHANNEL_INSTANCE_INTERNAL_STATE_H
+#define _AM_IMPLEMENTATION_CORE_PLAYBACK_CHANNEL_INSTANCE_INTERNAL_STATE_H
+
+#include <map>
+
+#include <SparkyStudios/Audio/Amplitude/Core/Common.h>
+#include <SparkyStudios/Audio/Amplitude/Core/Playback/ChannelInstance.h>
+#include <SparkyStudios/Audio/Amplitude/Core/Room.h>
+
+#include <Utils/intrusive_list.h>
+
+namespace SparkyStudios::Audio::Amplitude
+{
+    class ChannelInternalState;
+
+    /**
+     * @brief Internal state for a single channel instance (position).
+     *
+     * This class stores all the per-instance data needed for multi-position
+     * sound processing, including position, room association, attenuation
+     * weight, and playback cursor for separate mode.
+     */
+    class ChannelInstanceInternalState
+    {
+        friend class ChannelInstance;
+        friend class ChannelInternalState;
+
+    public:
+        /**
+         * @brief Creates a new uninitialized channel instance state.
+         */
+        ChannelInstanceInternalState();
+
+        /**
+         * @brief Creates a new channel instance state with a parent channel.
+         *
+         * @param parentChannel The parent channel that owns this instance.
+         */
+        explicit ChannelInstanceInternalState(ChannelInternalState* parentChannel);
+
+        /**
+         * @brief Resets this instance to its initial state.
+         */
+        void Reset();
+
+        /**
+         * @brief Gets the unique ID of this instance.
+         *
+         * @return The instance ID.
+         */
+        [[nodiscard]] AM_INLINE AmChannelInstanceID GetId() const
+        {
+            return _instanceId;
+        }
+
+        /**
+         * @brief Sets the unique ID of this instance.
+         *
+         * @param id The instance ID.
+         */
+        AM_INLINE void SetId(AmChannelInstanceID id)
+        {
+            _instanceId = id;
+        }
+
+        /**
+         * @brief Gets the world location of this instance.
+         *
+         * @return The world-space position.
+         */
+        [[nodiscard]] AM_INLINE const AmVector3& GetLocation() const
+        {
+            return _location;
+        }
+
+        /**
+         * @brief Sets the world location of this instance.
+         *
+         * @param location The new world-space position.
+         */
+        AM_INLINE void SetLocation(const AmVector3& location)
+        {
+            _previousLocation = _location;
+            _location = location;
+        }
+
+        /**
+         * @brief Gets the previous frame's location.
+         *
+         * @return The previous world-space position.
+         */
+        [[nodiscard]] AM_INLINE const AmVector3& GetPreviousLocation() const
+        {
+            return _previousLocation;
+        }
+
+        /**
+         * @brief Gets the room associated with this instance.
+         *
+         * @return The associated room.
+         */
+        [[nodiscard]] AM_INLINE const Room& GetRoom() const
+        {
+            return _room;
+        }
+
+        /**
+         * @brief Sets the room associated with this instance.
+         *
+         * @param room The room to associate.
+         */
+        void SetRoom(const Room& room);
+
+        /**
+         * @brief Gets the attenuation weight for blended mode.
+         *
+         * @return The weight value.
+         */
+        [[nodiscard]] AM_INLINE AmReal32 GetWeight() const
+        {
+            return _weight;
+        }
+
+        /**
+         * @brief Sets the attenuation weight for blended mode.
+         *
+         * @param weight The weight (clamped to be non-negative).
+         */
+        AM_INLINE void SetWeight(AmReal32 weight)
+        {
+            _weight = AM_MAX(weight, 0.0f);
+        }
+
+        /**
+         * @brief Gets the parent channel that owns this instance.
+         *
+         * @return The parent channel.
+         */
+        [[nodiscard]] AM_INLINE ChannelInternalState* GetParentChannel() const
+        {
+            return _parentChannel;
+        }
+
+        /**
+         * @brief Gets the playback cursor for this instance (separate mode).
+         *
+         * @return The cursor position in frames.
+         */
+        [[nodiscard]] AM_INLINE AmUInt64 GetCursor() const
+        {
+            return _cursor;
+        }
+
+        /**
+         * @brief Sets the playback cursor for this instance (separate mode).
+         *
+         * @param cursor The cursor position in frames.
+         */
+        AM_INLINE void SetCursor(AmUInt64 cursor)
+        {
+            _cursor = cursor;
+        }
+
+        /**
+         * @brief Advances the playback cursor by the given number of frames.
+         *
+         * @param frames The number of frames to advance.
+         * @param soundLength The total length of the sound in frames.
+         * @param loop Whether the sound should loop.
+         */
+        void AdvanceCursor(AmUInt64 frames, AmUInt64 soundLength, bool loop);
+
+        /**
+         * @brief Gets the loop count for this instance (separate mode).
+         *
+         * @return The number of times the sound has looped.
+         */
+        [[nodiscard]] AM_INLINE AmUInt32 GetLoopCount() const
+        {
+            return _loopCount;
+        }
+
+        /**
+         * @brief Checks if this instance has finished playing (separate mode).
+         *
+         * @return @c true if playback has finished, @c false otherwise.
+         */
+        [[nodiscard]] AM_INLINE bool IsFinished() const
+        {
+            return _finished;
+        }
+
+        /**
+         * @brief Gets the pre-computed attenuation gain for this instance.
+         *
+         * @return The computed gain value.
+         */
+        [[nodiscard]] AM_INLINE AmReal32 GetComputedGain() const
+        {
+            return _computedGain;
+        }
+
+        /**
+         * @brief Sets the pre-computed attenuation gain for this instance.
+         *
+         * @param gain The computed gain value.
+         */
+        AM_INLINE void SetComputedGain(AmReal32 gain)
+        {
+            _computedGain = gain;
+        }
+
+        /**
+         * @brief Gets the pre-computed stereo panned gain for this instance.
+         *
+         * @return The panned gain (left, right).
+         */
+        [[nodiscard]] AM_INLINE const AmVector2& GetPannedGain() const
+        {
+            return _pannedGain;
+        }
+
+        /**
+         * @brief Sets the pre-computed stereo panned gain for this instance.
+         *
+         * @param gain The panned gain (left, right).
+         */
+        AM_INLINE void SetPannedGain(const AmVector2& gain)
+        {
+            _pannedGain = gain;
+        }
+
+        /**
+         * @brief Gets the Doppler factor for a specific listener.
+         *
+         * @param listener The listener ID.
+         *
+         * @return The Doppler factor (1.0 = no shift).
+         */
+        [[nodiscard]] AmReal32 GetDopplerFactor(AmListenerID listener) const;
+
+        /**
+         * @brief Sets the Doppler factor for a specific listener.
+         *
+         * @param listener The listener ID.
+         * @param factor The Doppler factor.
+         */
+        void SetDopplerFactor(AmListenerID listener, AmReal32 factor);
+
+        /**
+         * @brief Intrusive list node for parent channel's instance list.
+         */
+        fplutil::intrusive_list_node instance_node;
+
+    private:
+        AmChannelInstanceID _instanceId;
+        ChannelInternalState* _parentChannel;
+
+        // Position
+        AmVector3 _location;
+        AmVector3 _previousLocation;
+
+        // Environment
+        Room _room;
+
+        // Blended mode weight
+        AmReal32 _weight;
+
+        // Separate mode: independent cursor
+        AmUInt64 _cursor;
+        AmUInt32 _loopCount;
+        bool _finished;
+
+        // Cached computed values for pipeline
+        AmReal32 _computedGain;
+        AmVector2 _pannedGain;
+
+        // Per-listener Doppler factors
+        std::map<AmListenerID, AmReal32> _dopplerFactors;
+    };
+
+    typedef fplutil::intrusive_list<ChannelInstanceInternalState> ChannelInstanceList;
+} // namespace SparkyStudios::Audio::Amplitude
+
+#endif // _AM_IMPLEMENTATION_CORE_PLAYBACK_CHANNEL_INSTANCE_INTERNAL_STATE_H

--- a/src/Core/Playback/ChannelInternalState.cpp
+++ b/src/Core/Playback/ChannelInternalState.cpp
@@ -793,4 +793,83 @@ namespace SparkyStudios::Audio::Amplitude
 
         return success;
     }
+
+    void ChannelInternalState::EnableInstancing(eChannelInstanceMode mode)
+    {
+        if (_instancingEnabled)
+            return; // Already enabled
+
+        _instancingEnabled = true;
+        _instancingMode = mode;
+        _nextInstanceId = 1;
+    }
+
+    void ChannelInternalState::DisableInstancing()
+    {
+        if (!_instancingEnabled)
+            return;
+
+        ClearInstances();
+
+        _instancingEnabled = false;
+        _instancingMode = eChannelInstanceMode_Blended;
+        _nextInstanceId = 1;
+    }
+
+    ChannelInstanceInternalState* ChannelInternalState::AddInstance(const AmVector3& location)
+    {
+        if (!_instancingEnabled)
+            return nullptr;
+
+        auto* instance = ampoolnew(eMemoryPoolKind_Engine, ChannelInstanceInternalState, this);
+        instance->SetId(_nextInstanceId++);
+        instance->SetLocation(location);
+
+        // For separate mode, initialize cursor at 0 if channel is already playing
+        // This allows instances to start at different points in time
+        if (_instancingMode == eChannelInstanceMode_Separate && !_realChannel._channelLayersId.empty())
+            instance->SetCursor(0);
+
+        _instances.push_back(*instance);
+        _instancesMap[instance->GetId()] = instance;
+
+        return instance;
+    }
+
+    void ChannelInternalState::RemoveInstance(AmChannelInstanceID instanceId)
+    {
+        auto it = _instancesMap.find(instanceId);
+        if (it == _instancesMap.end())
+            return;
+
+        ChannelInstanceInternalState* instance = it->second;
+        instance->instance_node.remove();
+        _instancesMap.erase(it);
+
+        ampooldelete(eMemoryPoolKind_Engine, ChannelInstanceInternalState, instance);
+    }
+
+    void ChannelInternalState::ClearInstances()
+    {
+        while (!_instances.empty())
+        {
+            ChannelInstanceInternalState& instance = _instances.front();
+            instance.instance_node.remove();
+            ampooldelete(eMemoryPoolKind_Engine, ChannelInstanceInternalState, &instance);
+        }
+
+        _instancesMap.clear();
+    }
+
+    ChannelInstanceInternalState* ChannelInternalState::GetInstance(AmChannelInstanceID instanceId)
+    {
+        auto it = _instancesMap.find(instanceId);
+        return it != _instancesMap.end() ? it->second : nullptr;
+    }
+
+    const ChannelInstanceInternalState* ChannelInternalState::GetInstance(AmChannelInstanceID instanceId) const
+    {
+        auto it = _instancesMap.find(instanceId);
+        return it != _instancesMap.end() ? it->second : nullptr;
+    }
 } // namespace SparkyStudios::Audio::Amplitude

--- a/src/Core/Playback/ChannelInternalState.cpp
+++ b/src/Core/Playback/ChannelInternalState.cpp
@@ -821,6 +821,12 @@ namespace SparkyStudios::Audio::Amplitude
         if (!_instancingEnabled)
             return nullptr;
 
+        if (_instances.size() >= kAmMaxChannelInstances)
+        {
+            amLogWarning("Cannot add instance: maximum limit of %zu instances reached.", kAmMaxChannelInstances);
+            return nullptr;
+        }
+
         auto* instance = ampoolnew(eMemoryPoolKind_Engine, ChannelInstanceInternalState, this);
         instance->SetId(_nextInstanceId++);
         instance->SetLocation(location);

--- a/src/Core/Playback/ChannelInternalState.h
+++ b/src/Core/Playback/ChannelInternalState.h
@@ -17,11 +17,16 @@
 #ifndef _AM_IMPLEMENTATION_CORE_PLAYBACK_CHANNEL_INTERNAL_STATE_H
 #define _AM_IMPLEMENTATION_CORE_PLAYBACK_CHANNEL_INTERNAL_STATE_H
 
+#include <map>
+
 #include <SparkyStudios/Audio/Amplitude/Core/Common.h>
 
 #include <SparkyStudios/Audio/Amplitude/Core/Entity.h>
 #include <SparkyStudios/Audio/Amplitude/Core/Playback/Channel.h>
 #include <SparkyStudios/Audio/Amplitude/Core/Playback/ChannelEventListener.h>
+#include <SparkyStudios/Audio/Amplitude/Core/Playback/ChannelInstance.h>
+
+#include <Core/Playback/ChannelInstanceInternalState.h>
 #include <SparkyStudios/Audio/Amplitude/Sound/Collection.h>
 #include <SparkyStudios/Audio/Amplitude/Sound/Sound.h>
 #include <SparkyStudios/Audio/Amplitude/Sound/Switch.h>
@@ -61,6 +66,11 @@ namespace SparkyStudios::Audio::Amplitude
             , _location()
             , _channelStateId(kAmInvalidObjectId)
             , _dopplerFactors()
+            , _instancingEnabled(false)
+            , _instancingMode(eChannelInstanceMode_Blended)
+            , _nextInstanceId(1)
+            , _instances(&ChannelInstanceInternalState::instance_node)
+            , _instancesMap()
         {}
 
         // Updates the state enum based on whether this channel is stopped, playing,
@@ -319,6 +329,107 @@ namespace SparkyStudios::Audio::Amplitude
 
         void Trigger(eChannelEvent event);
 
+        /**
+         * @brief Enables multi-position instancing for this channel.
+         *
+         * @param mode The instance mode.
+         */
+        void EnableInstancing(eChannelInstanceMode mode);
+
+        /**
+         * @brief Disables multi-position instancing for this channel.
+         */
+        void DisableInstancing();
+
+        /**
+         * @brief Checks if instancing is enabled for this channel.
+         *
+         * @return @c true if instancing is enabled, @c false otherwise.
+         */
+        [[nodiscard]] AM_INLINE bool IsInstancingEnabled() const
+        {
+            return _instancingEnabled;
+        }
+
+        /**
+         * @brief Gets the instancing mode.
+         *
+         * @return The current instancing mode.
+         */
+        [[nodiscard]] AM_INLINE eChannelInstanceMode GetInstancingMode() const
+        {
+            return _instancingMode;
+        }
+
+        /**
+         * @brief Adds a new instance at the specified location.
+         *
+         * @param location The world-space location for the new instance.
+         *
+         * @return The internal state of the new instance.
+         */
+        ChannelInstanceInternalState* AddInstance(const AmVector3& location);
+
+        /**
+         * @brief Removes an instance by ID.
+         *
+         * @param instanceId The ID of the instance to remove.
+         */
+        void RemoveInstance(AmChannelInstanceID instanceId);
+
+        /**
+         * @brief Removes all instances.
+         */
+        void ClearInstances();
+
+        /**
+         * @brief Gets an instance by ID.
+         *
+         * @param instanceId The ID of the instance to retrieve.
+         *
+         * @return The internal state of the instance, or nullptr if not found.
+         */
+        [[nodiscard]] ChannelInstanceInternalState* GetInstance(AmChannelInstanceID instanceId);
+
+        /**
+         * @brief Gets an instance by ID (const version).
+         *
+         * @param instanceId The ID of the instance to retrieve.
+         *
+         * @return The internal state of the instance, or nullptr if not found.
+         */
+        [[nodiscard]] const ChannelInstanceInternalState* GetInstance(AmChannelInstanceID instanceId) const;
+
+        /**
+         * @brief Gets the number of active instances.
+         *
+         * @return The number of instances.
+         */
+        [[nodiscard]] AM_INLINE AmSize GetInstanceCount() const
+        {
+            return _instances.size();
+        }
+
+        /**
+         * @brief Gets the list of instances.
+         *
+         * @return Reference to the instance list.
+         */
+        [[nodiscard]] AM_INLINE ChannelInstanceList& GetInstances()
+        {
+            return _instances;
+        }
+
+        /**
+         * @brief Gets the list of instances (const version).
+         *
+         * @return Const reference to the instance list.
+         */
+        [[nodiscard]] AM_INLINE const ChannelInstanceList& GetInstances() const
+        {
+            return _instances;
+        }
+
         // The node that tracks the location in the priority list.
         fplutil::intrusive_list_node priority_node;
 
@@ -396,6 +507,13 @@ namespace SparkyStudios::Audio::Amplitude
         std::map<AmRoomID, AmReal32> _roomGains;
 
         std::map<eChannelEvent, std::shared_ptr<ChannelEventListener>> _eventsMap;
+
+        // Multi-position instancing
+        bool _instancingEnabled;
+        eChannelInstanceMode _instancingMode;
+        AmChannelInstanceID _nextInstanceId;
+        ChannelInstanceList _instances;
+        std::map<AmChannelInstanceID, ChannelInstanceInternalState*> _instancesMap;
     };
 } // namespace SparkyStudios::Audio::Amplitude
 

--- a/src/Core/Playback/ChannelInternalState.h
+++ b/src/Core/Playback/ChannelInternalState.h
@@ -430,6 +430,26 @@ namespace SparkyStudios::Audio::Amplitude
             return _instances;
         }
 
+        /**
+         * @brief Gets the instance map.
+         *
+         * @return Reference to the instance map.
+         */
+        [[nodiscard]] AM_INLINE std::map<AmChannelInstanceID, ChannelInstanceInternalState*>& GetInstancesMap()
+        {
+            return _instancesMap;
+        }
+
+        /**
+         * @brief Gets the instance map.
+         *
+         * @return Const reference to the instance map.
+         */
+        [[nodiscard]] AM_INLINE const std::map<AmChannelInstanceID, ChannelInstanceInternalState*>& GetInstancesMap() const
+        {
+            return _instancesMap;
+        }
+
         // The node that tracks the location in the priority list.
         fplutil::intrusive_list_node priority_node;
 

--- a/src/Math/Orientation.cpp
+++ b/src/Math/Orientation.cpp
@@ -22,7 +22,7 @@ namespace SparkyStudios::Audio::Amplitude
 {
     Orientation Orientation::Zero()
     {
-        return { 0.0f, 0.0f, 0.0 };
+        return { 0.0f, 0.0f, 0.0f };
     }
 
     Orientation::Orientation(AmReal32 yaw, AmReal32 pitch, AmReal32 roll)

--- a/src/Mixer/Amplimix.cpp
+++ b/src/Mixer/Amplimix.cpp
@@ -15,6 +15,7 @@
 #include <SparkyStudios/Audio/Amplitude/Amplitude.h>
 
 #include <Core/Engine.h>
+#include <Core/Playback/ChannelInternalState.h>
 #include <Mixer/Amplimix.h>
 #include <Mixer/Pipeline.h>
 
@@ -440,6 +441,9 @@ namespace SparkyStudios::Audio::Amplitude
 
             UpdatePitch(&layer);
 
+            // Update cached instance data for multi-position processing
+            layer.UpdateInstanceData();
+
             hasMixedAtLeastOneLayer = true;
             MixLayer(&layer, &_scratchBuffer, frameCount);
 
@@ -848,8 +852,18 @@ namespace SparkyStudios::Audio::Amplitude
 
         if (_pipeline == nullptr || layer->pipeline == nullptr)
         {
-            amLogWarning("No active pipeline is set, this means no sound will be rendered. You should configure the Amplimix "
-                         "pipeline in your engine configuration file.");
+            amLogWarning(
+                "No active pipeline is set, this means no sound will be rendered. You should configure the Amplimix "
+                "pipeline in your engine configuration file.");
+            return;
+        }
+
+        // Check for separate mode instancing - process each instance independently
+        const auto& channel = layer->GetChannel();
+        if (channel.Valid() && channel.GetState()->IsInstancingEnabled() &&
+            channel.GetState()->GetInstancingMode() == eChannelInstanceMode_Separate && !layer->instanceData.empty())
+        {
+            MixLayerSeparateMode(layer, buffer, frameCount);
             return;
         }
 
@@ -1053,6 +1067,201 @@ namespace SparkyStudios::Audio::Amplitude
         }
     }
 
+    void AmplimixImpl::MixLayerSeparateMode(AmplimixLayerImpl* layer, AudioBuffer* buffer, AmUInt64 frameCount)
+    {
+        AmplimixLayerMutexLocker lock(layer);
+
+        if (layer->instanceData.empty())
+            return;
+
+        // load flag value atomically first
+        PlayStateFlag flag = AMPLIMIX_LOAD(&layer->flag);
+
+        // atomically load master gain
+        const AmReal32 gain = AMPLIMIX_LOAD(&_masterGain) * AMPLIMIX_LOAD(&layer->gain);
+
+#if defined(AM_SIMD_INTRINSICS)
+        auto bGain = simd_batch(gain);
+#else
+        const auto bGain = gain;
+#endif // AM_SIMD_INTRINSICS
+
+        // loop state
+        const bool loop = flag == ePSF_LOOP;
+
+        const AmUInt16 soundChannels = layer->snd->format.GetNumChannels();
+        const AmReal32 sampleRateRatio = AMPLIMIX_LOAD(&layer->sampleRateRatio);
+
+        AmUInt64 outSamples = frameCount;
+        AmUInt64 inSamples = frameCount;
+
+        if (sampleRateRatio != 1.0f)
+            inSamples = layer->dataConverter->GetRequiredInputFrameCount(outSamples) - layer->dataConverter->GetInputLatency();
+
+#if defined(AM_SIMD_INTRINSICS)
+        inSamples = AM_VALUE_ALIGN(inSamples, kProcessedFramesCount);
+#endif // AM_SIMD_INTRINSICS
+
+        const AmUInt64 start = layer->start;
+        const AmUInt64 end = layer->end;
+        bool allInstancesFinished = true;
+
+        // Get the channel's instance list for cursor updates
+        const auto& channel = layer->GetChannel();
+        if (!channel.Valid())
+            return;
+
+        auto& instances = channel.GetState()->GetInstances();
+
+        // Process each instance
+        for (AmSize instanceIndex = 0; instanceIndex < layer->instanceData.size(); ++instanceIndex)
+        {
+            auto& data = layer->instanceData[instanceIndex];
+
+            if (data.cursor >= end)
+                continue;
+
+            allInstancesFinished = false;
+
+            // Set instance context for pipeline nodes
+            layer->processingInstance = true;
+            layer->currentInstanceIndex = instanceIndex;
+
+            AmUInt64 instanceCursor = data.cursor;
+
+            // Create buffers for this instance
+            SoundChunk* in = SoundChunk::CreateChunk(inSamples, soundChannels, eMemoryPoolKind_Amplimix);
+            SoundChunk* transient = SoundChunk::CreateChunk(outSamples, 1, eMemoryPoolKind_Amplimix);
+            SoundChunk* out = SoundChunk::CreateChunk(transient->frames, 2, eMemoryPoolKind_Amplimix);
+
+            if (layer->snd->stream)
+            {
+                AmUInt64 c = inSamples;
+                while (c > 0 && flag != ePSF_MIN)
+                {
+                    flag = AMPLIMIX_LOAD(&layer->flag);
+                    if (flag == ePSF_MIN)
+                        break;
+
+                    const AmUInt64 chunkSize = AM_MIN(layer->snd->chunk->frames, c);
+                    AmUInt64 readLen = chunkSize;
+
+#if defined(AM_SIMD_INTRINSICS)
+                    readLen = AM_VALUE_ALIGN(readLen, kProcessedFramesCount);
+#endif // AM_SIMD_INTRINSICS
+
+                    readLen = OnSoundStream(this, layer, (instanceCursor + (inSamples - c)) % layer->snd->length, readLen);
+                    readLen = AM_MIN(readLen, chunkSize);
+
+                    if (readLen == 0)
+                        break;
+
+                    AudioBuffer::Copy(*layer->snd->chunk->buffer, 0, *in->buffer, inSamples - c, readLen);
+                    c -= readLen;
+                }
+            }
+            else
+            {
+                const AmUInt64 offset = instanceCursor % layer->snd->length;
+                const AmUInt64 remaining = layer->snd->chunk->frames - instanceCursor;
+
+                if (instanceCursor < layer->snd->chunk->frames && remaining < inSamples)
+                {
+                    AudioBuffer::Copy(*layer->snd->chunk->buffer, offset, *in->buffer, 0, remaining);
+                    AudioBuffer::Copy(*layer->snd->chunk->buffer, 0, *in->buffer, remaining, in->frames - remaining);
+                }
+                else
+                {
+                    AudioBuffer::Copy(*layer->snd->chunk->buffer, offset, *in->buffer, 0, in->frames);
+                }
+            }
+
+            // Convert sample rate
+            layer->dataConverter->Process(*in->buffer, inSamples, *transient->buffer, outSamples);
+
+            if (outSamples > 0 && flag >= ePSF_PLAY)
+            {
+                layer->pipeline->Execute(*transient->buffer, *out->buffer);
+
+                AmReal64 position = instanceCursor;
+                const AmReal64 step = static_cast<AmReal64>(inSamples) / static_cast<AmReal64>(outSamples);
+
+                // Mix into output buffer
+                for (AmUInt64 i = 0; i < outSamples; i += kProcessedFramesCount)
+                {
+                    position = AM_CLAMP(position, static_cast<AmReal64>(start), static_cast<AmReal64>(end));
+
+                    if (std::ceil(position) == end)
+                    {
+                        if (loop)
+                            position = start;
+                        else
+                            break;
+                    }
+
+                    switch (_device.mRequestedOutputChannels)
+                    {
+                    case PlaybackOutputChannels::Mono:
+                        MixMono(i, bGain, out->buffer->GetChannel(0), buffer->GetChannel(0));
+                        break;
+
+                    case PlaybackOutputChannels::Stereo:
+                        MixMono(i, bGain, out->buffer->GetChannel(0), buffer->GetChannel(0));
+                        MixMono(i, bGain, out->buffer->GetChannel(1), buffer->GetChannel(1));
+                        break;
+
+                    default:
+                        amLogWarning("The mixer cannot handle the requested output channels.");
+                        break;
+                    }
+
+                    position += step * kProcessedFramesCount;
+                }
+
+                instanceCursor += inSamples;
+                instanceCursor = AM_CLAMP(instanceCursor, start, end);
+            }
+
+            // Update the instance's cursor in the internal state
+            data.cursor = instanceCursor;
+
+            // Update the actual instance state (find it by index in the intrusive list)
+            AmSize idx = 0;
+            for (auto& instanceState : instances)
+            {
+                if (idx == instanceIndex)
+                {
+                    instanceState.SetCursor(instanceCursor);
+                    break;
+                }
+                ++idx;
+            }
+
+            // Reset pipeline for next instance
+            layer->pipeline->Reset();
+
+            SoundChunk::DestroyChunk(out);
+            SoundChunk::DestroyChunk(transient);
+            SoundChunk::DestroyChunk(in);
+        }
+
+        // Clear instance processing context
+        layer->processingInstance = false;
+        layer->currentInstanceIndex = 0;
+
+        // If all instances finished, trigger end callback
+        if (allInstancesFinished && !loop)
+        {
+            const MixerCommandCallback callback = [this, layer]() -> bool
+            {
+                OnSoundEnded(this, layer);
+                return true;
+            };
+
+            PushCommand({ callback });
+        }
+    }
+
     AmplimixLayerImpl* AmplimixImpl::GetLayer(AmUInt32 layer)
     {
         // get layer based on the lowest bits of layer id
@@ -1193,6 +1402,9 @@ namespace SparkyStudios::Audio::Amplitude
         if (snd == nullptr || snd->sound == nullptr)
             return kVector3Zero;
 
+        if (processingInstance && currentInstanceIndex < instanceData.size())
+            return instanceData[currentInstanceIndex].location;
+
         return snd->sound->GetChannel().GetLocation();
     }
 
@@ -1216,6 +1428,9 @@ namespace SparkyStudios::Audio::Amplitude
     {
         if (snd == nullptr || snd->sound == nullptr)
             return Room(nullptr);
+
+        if (processingInstance && currentInstanceIndex < instanceData.size())
+            return instanceData[currentInstanceIndex].room;
 
         return snd->sound->GetChannel().GetRoom();
     }
@@ -1299,5 +1514,100 @@ namespace SparkyStudios::Audio::Amplitude
 
         const AmReal32 ratio = AMPLIMIX_LOAD(&sampleRateRatio);
         return snd->format.GetSampleRate() * ratio;
+    }
+
+    bool AmplimixLayerImpl::IsMultiPosition() const
+    {
+        if (snd == nullptr || snd->sound == nullptr)
+            return false;
+
+        if (processingInstance)
+            return false;
+
+        const auto& channel = snd->sound->GetChannel();
+        if (!channel.Valid())
+            return false;
+
+        auto* channelState = channel.GetState();
+        return channelState->IsInstancingEnabled() && channelState->GetInstanceCount() > 0;
+    }
+
+    eChannelInstanceMode AmplimixLayerImpl::GetInstancingMode() const
+    {
+        if (snd == nullptr || snd->sound == nullptr)
+            return eChannelInstanceMode_Blended;
+
+        const auto& channel = snd->sound->GetChannel();
+        if (!channel.Valid())
+            return eChannelInstanceMode_Blended;
+
+        return channel.GetState()->GetInstancingMode();
+    }
+
+    AmSize AmplimixLayerImpl::GetInstanceCount() const
+    {
+        return instanceData.size();
+    }
+
+    AmVector3 AmplimixLayerImpl::GetInstanceLocation(AmSize index) const
+    {
+        if (index >= instanceData.size())
+            return kVector3Zero;
+
+        return instanceData[index].location;
+    }
+
+    Room AmplimixLayerImpl::GetInstanceRoom(AmSize index) const
+    {
+        if (index >= instanceData.size())
+            return Room();
+
+        return instanceData[index].room;
+    }
+
+    AmReal32 AmplimixLayerImpl::GetInstanceWeight(AmSize index) const
+    {
+        if (index >= instanceData.size())
+            return 1.0f;
+
+        return instanceData[index].weight;
+    }
+
+    AmReal32 AmplimixLayerImpl::GetInstanceGain(AmSize index) const
+    {
+        if (index >= instanceData.size())
+            return 1.0f;
+
+        return instanceData[index].computedGain;
+    }
+
+    void AmplimixLayerImpl::UpdateInstanceData()
+    {
+        instanceData.clear();
+
+        if (snd == nullptr || snd->sound == nullptr)
+            return;
+
+        const auto& channel = snd->sound->GetChannel();
+        if (!channel.Valid())
+            return;
+
+        auto* channelState = channel.GetState();
+        if (!channelState->IsInstancingEnabled())
+            return;
+
+        const auto& instances = channelState->GetInstances();
+        instanceData.reserve(instances.size());
+
+        for (const auto& instance : instances)
+        {
+            InstanceData data;
+            data.location = instance.GetLocation();
+            data.room = instance.GetRoom();
+            data.weight = instance.GetWeight();
+            data.computedGain = instance.GetComputedGain();
+            data.cursor = instance.GetCursor(); // For separate mode
+            instanceData.push_back(data);
+        }
     }
 } // namespace SparkyStudios::Audio::Amplitude

--- a/src/Mixer/Amplimix.cpp
+++ b/src/Mixer/Amplimix.cpp
@@ -1113,6 +1113,11 @@ namespace SparkyStudios::Audio::Amplitude
 
         auto& instances = channel.GetState()->GetInstances();
 
+        // Pre-allocate buffers for instance processing
+        SoundChunk* in = SoundChunk::CreateChunk(inSamples, soundChannels, eMemoryPoolKind_Amplimix);
+        SoundChunk* transient = SoundChunk::CreateChunk(outSamples, 1, eMemoryPoolKind_Amplimix);
+        SoundChunk* out = SoundChunk::CreateChunk(outSamples, 2, eMemoryPoolKind_Amplimix);
+
         // Process each instance
         for (AmSize instanceIndex = 0; instanceIndex < layer->instanceData.size(); ++instanceIndex)
         {
@@ -1129,10 +1134,10 @@ namespace SparkyStudios::Audio::Amplitude
 
             AmUInt64 instanceCursor = data.cursor;
 
-            // Create buffers for this instance
-            SoundChunk* in = SoundChunk::CreateChunk(inSamples, soundChannels, eMemoryPoolKind_Amplimix);
-            SoundChunk* transient = SoundChunk::CreateChunk(outSamples, 1, eMemoryPoolKind_Amplimix);
-            SoundChunk* out = SoundChunk::CreateChunk(transient->frames, 2, eMemoryPoolKind_Amplimix);
+            // Clear buffers for reuse
+            in->buffer->Clear();
+            transient->buffer->Clear();
+            out->buffer->Clear();
 
             if (layer->snd->stream)
             {
@@ -1222,32 +1227,36 @@ namespace SparkyStudios::Audio::Amplitude
                 instanceCursor = AM_CLAMP(instanceCursor, start, end);
             }
 
-            // Update the instance's cursor in the internal state
+            // Update the instance's cursor in the cached data
             data.cursor = instanceCursor;
 
-            // Update the actual instance state (find it by index in the intrusive list)
-            AmSize idx = 0;
-            for (auto& instanceState : instances)
+            // Update the actual instance state
+            const AmChannelInstanceID instanceId = data.instanceId;
+            auto& instancesMap = channel.GetState()->GetInstancesMap();
+            auto it = instancesMap.find(instanceId);
+
+            if (it != instancesMap.end())
             {
-                if (idx == instanceIndex)
-                {
-                    instanceState.SetCursor(instanceCursor);
-                    break;
-                }
-                ++idx;
+                it->second->SetCursor(instanceCursor);
+            }
+            else
+            {
+                // Instance was removed during processing, skip update
+                amLogWarning("Instance " AM_ID_CHAR_FMT " was removed during audio processing, skipping cursor update.", instanceId);
             }
 
-            // Reset pipeline for next instance
+            // Reset pipeline state for next instance. This is required since each
+            // instance needs to be processed as a single sound object in separate mode.
             layer->pipeline->Reset();
-
-            SoundChunk::DestroyChunk(out);
-            SoundChunk::DestroyChunk(transient);
-            SoundChunk::DestroyChunk(in);
         }
 
         // Clear instance processing context
         layer->processingInstance = false;
         layer->currentInstanceIndex = 0;
+
+        SoundChunk::DestroyChunk(out);
+        SoundChunk::DestroyChunk(transient);
+        SoundChunk::DestroyChunk(in);
 
         // If all instances finished, trigger end callback
         if (allInstancesFinished && !loop)
@@ -1346,7 +1355,9 @@ namespace SparkyStudios::Audio::Amplitude
     {
         pipeline->Reset();
 
-        // Update pending states
+        // Clear room update flag to allow re-initialization for next processing pass
+        // This is important for per-instance processing in separate mode, where each
+        // instance may be in a different room and requires independent room handling
         const Room& room = GetRoom();
         if (room.Valid())
             room.GetState()->SetWasUpdated(false);
@@ -1602,6 +1613,7 @@ namespace SparkyStudios::Audio::Amplitude
         for (const auto& instance : instances)
         {
             InstanceData data;
+            data.instanceId = instance.GetId();
             data.location = instance.GetLocation();
             data.room = instance.GetRoom();
             data.weight = instance.GetWeight();

--- a/src/Mixer/Amplimix.h
+++ b/src/Mixer/Amplimix.h
@@ -116,6 +116,48 @@ namespace SparkyStudios::Audio::Amplitude
         [[nodiscard]] const std::shared_ptr<EffectInstance> GetEffect() const override;
         [[nodiscard]] const Attenuation* GetAttenuation() const override;
         [[nodiscard]] AmUInt32 GetSampleRate() const override;
+        [[nodiscard]] bool IsMultiPosition() const override;
+        [[nodiscard]] eChannelInstanceMode GetInstancingMode() const override;
+        [[nodiscard]] AmSize GetInstanceCount() const override;
+        [[nodiscard]] AmVector3 GetInstanceLocation(AmSize index) const override;
+        [[nodiscard]] Room GetInstanceRoom(AmSize index) const override;
+        [[nodiscard]] AmReal32 GetInstanceWeight(AmSize index) const override;
+        [[nodiscard]] AmReal32 GetInstanceGain(AmSize index) const override;
+
+        /**
+         * @brief Cached per-instance data for pipeline processing.
+         */
+        struct InstanceData
+        {
+            AmVector3 location;
+            Room room;
+            AmReal32 weight;
+            AmReal32 computedGain;
+            AmUInt64 cursor; // For separate mode
+        };
+
+        /**
+         * @brief Updates the cached instance data from the channel state.
+         */
+        void UpdateInstanceData();
+
+        /**
+         * @brief Cached instance data for multi-position processing.
+         */
+        std::vector<InstanceData> instanceData;
+
+        /**
+         * @brief Whether we are currently processing a specific instance (separate mode).
+         *
+         * When true, IsMultiPosition() returns false and GetLocation() returns
+         * the current instance's location.
+         */
+        bool processingInstance = false;
+
+        /**
+         * @brief The index of the current instance being processed (separate mode).
+         */
+        AmSize currentInstanceIndex = 0;
     };
 
     struct MixerCommand
@@ -224,6 +266,7 @@ namespace SparkyStudios::Audio::Amplitude
 
         void ExecuteCommands();
         void MixLayer(AmplimixLayerImpl* layer, AudioBuffer* buffer, AmUInt64 frameCount);
+        void MixLayerSeparateMode(AmplimixLayerImpl* layer, AudioBuffer* buffer, AmUInt64 frameCount);
         AmplimixLayerImpl* GetLayer(AmUInt32 layer);
         bool ShouldMix(AmplimixLayerImpl* layer);
         void UpdatePitch(AmplimixLayerImpl* layer);

--- a/src/Mixer/Amplimix.h
+++ b/src/Mixer/Amplimix.h
@@ -91,6 +91,13 @@ namespace SparkyStudios::Audio::Amplitude
          */
         void Reset();
 
+        /**
+         * @brief Resets the pipeline to its initial state.
+         *
+         * This clears all stateful nodes (filters, reverbs, etc.) and resets
+         * room update flags. Should be called between instance processing in
+         * separate mode to ensure independent processing per spatial position.
+         */
         void ResetPipeline();
 
         [[nodiscard]] AmUInt32 GetId() const override;
@@ -129,6 +136,7 @@ namespace SparkyStudios::Audio::Amplitude
          */
         struct InstanceData
         {
+            AmChannelInstanceID instanceId;
             AmVector3 location;
             Room room;
             AmReal32 weight;

--- a/src/Mixer/Nodes/AmbisonicPanningNode.cpp
+++ b/src/Mixer/Nodes/AmbisonicPanningNode.cpp
@@ -38,15 +38,56 @@ namespace SparkyStudios::Audio::Amplitude
         if (!listener.Valid())
             return nullptr;
 
-        const auto& listenerSpaceSourcePosition = Transform(listener.GetInverseMatrix(), { .xyz = layer->GetLocation(), ._pad2 = 1.0f });
-
         const ePanningMode mode = Engine::GetInstance()->GetPanningMode();
         const AmUInt32 order = AM_MAX(static_cast<AmUInt32>(mode), 1u);
 
         _soundField.Configure(order, true, input->GetFrameCount());
+        _soundField.Reset();
 
-        _source.SetPosition(SphericalPosition::ForHRTF(listenerSpaceSourcePosition.xyz), 0.25f);
-        _source.Process(input->GetChannel(0), input->GetFrameCount(), &_soundField);
+        if (layer->IsMultiPosition())
+        {
+            const AmSize instanceCount = layer->GetInstanceCount();
+            AmReal32 totalWeight = 0.0f;
+
+            for (AmSize i = 0; i < instanceCount; ++i)
+            {
+                const AmVector3 location = layer->GetInstanceLocation(i);
+                const AmReal32 weight = layer->GetInstanceWeight(i);
+                const AmReal32 instanceGain = layer->GetInstanceGain(i);
+
+                const auto& listenerSpacePosition = Transform(listener.GetInverseMatrix(), { .xyz = location, ._pad2 = 1.0f });
+                _source.SetPosition(SphericalPosition::ForHRTF(listenerSpacePosition.xyz), 0.25f);
+
+                // Create a temporary soundfield for this instance
+                BFormat tempField;
+                tempField.Configure(order, true, input->GetFrameCount());
+                tempField.Reset();
+
+                // Scale input by weight and gain for this instance
+                AudioBuffer scaledInput(input->GetFrameCount(), 1);
+                const AmReal32 scaleFactor = weight * instanceGain;
+                ScalarMultiply(input->GetChannel(0).begin(), scaledInput[0].begin(), scaleFactor, input->GetFrameCount());
+
+                _source.Process(scaledInput.GetChannel(0), input->GetFrameCount(), &tempField);
+
+                // Accumulate into main soundfield
+                _soundField += tempField;
+                totalWeight += weight;
+            }
+
+            // Normalize by total weight if needed
+            if (totalWeight > kEpsilon && totalWeight != 1.0f)
+            {
+                const AmReal32 normFactor = 1.0f / totalWeight;
+                _soundField *= normFactor;
+            }
+        }
+        else
+        {
+            const auto& listenerSpaceSourcePosition = Transform(listener.GetInverseMatrix(), { .xyz = layer->GetLocation(), ._pad2 = 1.0f });
+            _source.SetPosition(SphericalPosition::ForHRTF(listenerSpaceSourcePosition.xyz), 0.25f);
+            _source.Process(input->GetChannel(0), input->GetFrameCount(), &_soundField);
+        }
 
         return _soundField.GetBuffer();
     }

--- a/src/Mixer/Nodes/AttenuationNode.cpp
+++ b/src/Mixer/Nodes/AttenuationNode.cpp
@@ -191,6 +191,7 @@ namespace SparkyStudios::Audio::Amplitude
         const Listener& listener = layer->GetListener();
 
         AmReal32 targetGain = 1.0f;
+        AmVector3 effectiveLocation = layer->GetLocation();
 
         // Compute attenuated gain based on spatialization
         {
@@ -198,23 +199,53 @@ namespace SparkyStudios::Audio::Amplitude
 
             if (listener.Valid())
             {
-                const Entity& entity = layer->GetEntity();
+                if (layer->IsMultiPosition())
+                {
+                    const AmSize instanceCount = layer->GetInstanceCount();
+                    AmReal32 totalWeight = 0.0f;
+                    AmReal32 blendedGain = 0.0f;
+                    AmVector3 weightedLocation = kVector3Zero;
 
-                if (spatialization == eSpatialization_PositionOrientation)
-                {
-                    AMPLITUDE_ASSERT(entity.Valid());
-                    targetGain *= attenuation->GetGain(entity, listener);
-                }
-                else if (spatialization == eSpatialization_HRTF && entity.Valid())
-                {
-                    targetGain *= attenuation->GetGain(entity, listener);
-                }
-                else if (spatialization == eSpatialization_Position)
-                {
-                    const AmVector3& location = layer->GetLocation();
+                    for (AmSize i = 0; i < instanceCount; ++i)
+                    {
+                        const AmVector3 location = layer->GetInstanceLocation(i);
+                        const AmReal32 weight = layer->GetInstanceWeight(i);
+                        const AmReal32 instanceGain = attenuation->GetGain(location, listener);
 
-                    // Position-based spatialization, or HRTF-based spatialization without entity
-                    targetGain *= attenuation->GetGain(location, listener);
+                        blendedGain += instanceGain * weight;
+                        weightedLocation = Add(weightedLocation, Scale(location, weight));
+                        totalWeight += weight;
+                    }
+
+                    // Normalize by total weight
+                    if (totalWeight > kEpsilon)
+                    {
+                        targetGain = blendedGain / totalWeight;
+                        effectiveLocation = Scale(weightedLocation, 1.0f / totalWeight);
+                    }
+                    else
+                    {
+                        targetGain = 0.0f;
+                    }
+                }
+                else
+                {
+                    const Entity& entity = layer->GetEntity();
+
+                    if (spatialization == eSpatialization_PositionOrientation)
+                    {
+                        AMPLITUDE_ASSERT(entity.Valid());
+                        targetGain *= attenuation->GetGain(entity, listener);
+                    }
+                    else if (spatialization == eSpatialization_HRTF && entity.Valid())
+                    {
+                        targetGain *= attenuation->GetGain(entity, listener);
+                    }
+                    else if (spatialization == eSpatialization_Position)
+                    {
+                        // Position-based spatialization, or HRTF-based spatialization without entity
+                        targetGain *= attenuation->GetGain(effectiveLocation, listener);
+                    }
                 }
             }
             else
@@ -227,14 +258,13 @@ namespace SparkyStudios::Audio::Amplitude
         if (Gain::IsZero(targetGain))
             return nullptr;
 
-        // Set and normalize gains
+        // Set and normalize gains for air absorption
         if (attenuation->IsAirAbsorptionEnabled() && listener.Valid())
         {
-            const AmVector3& soundLocation = layer->GetLocation();
             const AmVector3& listenerLocation = listener.GetLocation();
 
             for (AmUInt32 i = 0; i < kAmAirAbsorptionBandCount; ++i)
-                _gains[i] = attenuation->EvaluateAirAbsorption(soundLocation, listenerLocation, i);
+                _gains[i] = attenuation->EvaluateAirAbsorption(effectiveLocation, listenerLocation, i);
 
             AirAbsorptionEQFilter::Normalize(_gains, targetGain);
             _eqFilter.SetGains(_gains[0], _gains[1], _gains[2]);

--- a/src/Mixer/Nodes/AttenuationNode.cpp
+++ b/src/Mixer/Nodes/AttenuationNode.cpp
@@ -218,14 +218,18 @@ namespace SparkyStudios::Audio::Amplitude
                     }
 
                     // Normalize by total weight
-                    if (totalWeight > kEpsilon)
+                    constexpr AmReal32 kMinTotalWeight = 1e-3f;
+
+                    if (totalWeight > kMinTotalWeight)
                     {
-                        targetGain = blendedGain / totalWeight;
-                        effectiveLocation = Scale(weightedLocation, 1.0f / totalWeight);
+                        const AmReal32 invTotalWeight = 1.0f / totalWeight;
+                        targetGain = blendedGain * invTotalWeight;
+                        effectiveLocation = Scale(weightedLocation, invTotalWeight);
                     }
                     else
                     {
                         targetGain = 0.0f;
+                        effectiveLocation = kVector3Zero;
                     }
                 }
                 else

--- a/src/Mixer/Nodes/StereoPanningNode.cpp
+++ b/src/Mixer/Nodes/StereoPanningNode.cpp
@@ -37,16 +37,49 @@ namespace SparkyStudios::Audio::Amplitude
         _output = AudioBuffer(input->GetFrameCount(), 2);
 
         constexpr AmReal32 kGain = 1.0f;
-        AmVector2 pannedGain = kVector2Zero;
 
         if (layer->GetSpatialization() == eSpatialization_None)
-            pannedGain = Gain::CalculateStereoPannedGain(kGain, 0.0f);
-        else
-            pannedGain = Gain::CalculateStereoPannedGain(kGain, layer->GetLocation(), listener.GetInverseMatrix());
+        {
+            const AmVector2 pannedGain = Gain::CalculateStereoPannedGain(kGain, 0.0f);
+            Gain::ApplyReplaceConstantGain(pannedGain.x, input->GetChannel(0), 0, _output[0], 0, _output.GetFrameCount());
+            Gain::ApplyReplaceConstantGain(pannedGain.y, input->GetChannel(0), 0, _output[1], 0, _output.GetFrameCount());
+        }
+        else if (layer->IsMultiPosition())
+        {
+            const AmSize instanceCount = layer->GetInstanceCount();
+            AmReal32 totalWeight = 0.0f;
+            AmVector2 blendedPan = kVector2Zero;
 
-        // Apply panning
-        Gain::ApplyReplaceConstantGain(pannedGain.x, input->GetChannel(0), 0, _output[0], 0, _output.GetFrameCount());
-        Gain::ApplyReplaceConstantGain(pannedGain.y, input->GetChannel(0), 0, _output[1], 0, _output.GetFrameCount());
+            for (AmSize i = 0; i < instanceCount; ++i)
+            {
+                const AmVector3 location = layer->GetInstanceLocation(i);
+                const AmReal32 weight = layer->GetInstanceWeight(i);
+                const AmReal32 instanceGain = layer->GetInstanceGain(i);
+
+                const AmVector2 pannedGain = Gain::CalculateStereoPannedGain(instanceGain, location, listener.GetInverseMatrix());
+
+                blendedPan.x += pannedGain.x * weight;
+                blendedPan.y += pannedGain.y * weight;
+                totalWeight += weight;
+            }
+
+            // Normalize by total weight
+            if (totalWeight > kEpsilon)
+            {
+                blendedPan.x /= totalWeight;
+                blendedPan.y /= totalWeight;
+            }
+
+            // Apply blended panning
+            Gain::ApplyReplaceConstantGain(blendedPan.x, input->GetChannel(0), 0, _output[0], 0, _output.GetFrameCount());
+            Gain::ApplyReplaceConstantGain(blendedPan.y, input->GetChannel(0), 0, _output[1], 0, _output.GetFrameCount());
+        }
+        else
+        {
+            const AmVector2 pannedGain = Gain::CalculateStereoPannedGain(kGain, layer->GetLocation(), listener.GetInverseMatrix());
+            Gain::ApplyReplaceConstantGain(pannedGain.x, input->GetChannel(0), 0, _output[0], 0, _output.GetFrameCount());
+            Gain::ApplyReplaceConstantGain(pannedGain.y, input->GetChannel(0), 0, _output[1], 0, _output.GetFrameCount());
+        }
 
         return &_output;
     }

--- a/tests/core_channel_instances/test_blended_mode_shares_cursor.cpp
+++ b/tests/core_channel_instances/test_blended_mode_shares_cursor.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Enable blended mode
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+        AM_EXPECT(channel.GetInstancingMode() == eChannelInstanceMode_Blended);
+
+        // Add multiple instances
+        AM_UNUSED(channel.AddInstance({ 100.0f, 0.0f, 50.0f }));
+        AM_UNUSED(channel.AddInstance({ 120.0f, 0.0f, 80.0f }));
+        AM_UNUSED(channel.AddInstance({ 140.0f, 0.0f, 110.0f }));
+
+        AM_EXPECT(channel.GetInstanceCount() == 3);
+
+        // In blended mode, all instances share the same playback cursor
+        // We can't directly test the cursor sharing without accessing internal state,
+        // but we can verify that the channel is playing and the mode is correct
+        AM_EXPECT(channel.Playing());
+        AM_EXPECT(channel.GetInstancingMode() == eChannelInstanceMode_Blended);
+
+        // Advance a few frames to let the sound play
+        amEngine->WaitUntilFrames(10);
+
+        // Channel should still be playing
+        AM_EXPECT(channel.Playing());
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_blended_mode_weighted_instances.cpp
+++ b/tests/core_channel_instances/test_blended_mode_weighted_instances.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Enable blended mode
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+
+        // Add instances with different weights
+        ChannelInstance instance1 = channel.AddInstance({ 100.0f, 0.0f, 50.0f });
+        instance1.SetWeight(1.0f);
+
+        ChannelInstance instance2 = channel.AddInstance({ 120.0f, 0.0f, 80.0f });
+        instance2.SetWeight(0.5f);
+
+        ChannelInstance instance3 = channel.AddInstance({ 140.0f, 0.0f, 110.0f });
+        instance3.SetWeight(1.5f);
+
+        // Verify weights are set correctly
+        AM_EXPECT(std::abs(instance1.GetWeight() - 1.0f) < kEpsilon);
+        AM_EXPECT(std::abs(instance2.GetWeight() - 0.5f) < kEpsilon);
+        AM_EXPECT(std::abs(instance3.GetWeight() - 1.5f) < kEpsilon);
+
+        // Let the sound play with weighted blending
+        amEngine->WaitUntilFrames(10);
+
+        // Channel should be playing with weighted blend attenuation
+        AM_EXPECT(channel.Playing());
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_can_add_and_remove_instances.cpp
+++ b/tests/core_channel_instances/test_can_add_and_remove_instances.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Enable instancing
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+        AM_EXPECT(channel.GetInstanceCount() == 0);
+
+        // Add instances
+        ChannelInstance instance1 = channel.AddInstance({ 100.0f, 0.0f, 50.0f });
+        AM_EXPECT(instance1.Valid());
+        AM_EXPECT(channel.GetInstanceCount() == 1);
+
+        ChannelInstance instance2 = channel.AddInstance({ 120.0f, 0.0f, 80.0f });
+        AM_EXPECT(instance2.Valid());
+        AM_EXPECT(channel.GetInstanceCount() == 2);
+
+        ChannelInstance instance3 = channel.AddInstance({ 140.0f, 0.0f, 110.0f });
+        AM_EXPECT(instance3.Valid());
+        AM_EXPECT(channel.GetInstanceCount() == 3);
+
+        // Remove an instance
+        channel.RemoveInstance(instance2.GetId());
+        AM_EXPECT(channel.GetInstanceCount() == 2);
+
+        // Try to get removed instance - should be invalid
+        ChannelInstance removedInstance = channel.GetInstance(instance2.GetId());
+        AM_EXPECT_NOT(removedInstance.Valid());
+
+        // Clear all instances
+        channel.ClearInstances();
+        AM_EXPECT(channel.GetInstanceCount() == 0);
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_can_enable_and_disable_instancing.cpp
+++ b/tests/core_channel_instances/test_can_enable_and_disable_instancing.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Test initial state - instancing should be disabled
+        AM_EXPECT(!channel.IsInstancingEnabled());
+
+        // Enable blended mode
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+        AM_EXPECT(channel.IsInstancingEnabled());
+        AM_EXPECT(channel.GetInstancingMode() == eChannelInstanceMode_Blended);
+
+        // Disable instancing
+        channel.DisableInstancing();
+        AM_EXPECT(!channel.IsInstancingEnabled());
+
+        // Enable separate mode
+        channel.EnableInstancing(eChannelInstanceMode_Separate);
+        AM_EXPECT(channel.IsInstancingEnabled());
+        AM_EXPECT(channel.GetInstancingMode() == eChannelInstanceMode_Separate);
+
+        // Disable again
+        channel.DisableInstancing();
+        AM_EXPECT(!channel.IsInstancingEnabled());
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_can_set_instance_properties.cpp
+++ b/tests/core_channel_instances/test_can_set_instance_properties.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Enable instancing
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+
+        // Add an instance
+        ChannelInstance instance = channel.AddInstance({ 100.0f, 0.0f, 50.0f });
+        AM_EXPECT(instance.Valid());
+
+        // Test location getter
+        const AmVector3& location = instance.GetLocation();
+        AM_EXPECT(std::abs(location.x - 100.0f) < kEpsilon);
+        AM_EXPECT(std::abs(location.y - 0.0f) < kEpsilon);
+        AM_EXPECT(std::abs(location.z - 50.0f) < kEpsilon);
+
+        // Test location setter
+        instance.SetLocation({ 200.0f, 10.0f, 100.0f });
+        const AmVector3& newLocation = instance.GetLocation();
+        AM_EXPECT(std::abs(newLocation.x - 200.0f) < kEpsilon);
+        AM_EXPECT(std::abs(newLocation.y - 10.0f) < kEpsilon);
+        AM_EXPECT(std::abs(newLocation.z - 100.0f) < kEpsilon);
+
+        // Test weight getter (default should be 1.0)
+        AmReal32 weight = instance.GetWeight();
+        AM_EXPECT(std::abs(weight - 1.0f) < kEpsilon);
+
+        // Test weight setter
+        instance.SetWeight(0.75f);
+        weight = instance.GetWeight();
+        AM_EXPECT(std::abs(weight - 0.75f) < kEpsilon);
+
+        // Test room getter (default should be invalid)
+        Room room = instance.GetRoom();
+        AM_EXPECT(!room.Valid());
+
+        // Test room setter
+        Room testRoom = amEngine->AddRoom(1);
+        instance.SetRoom(testRoom);
+        room = instance.GetRoom();
+        AM_EXPECT(room.Valid());
+        AM_EXPECT(room.GetId() == testRoom.GetId());
+
+        // Cleanup
+        amEngine->RemoveRoom(1);
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_can_switch_between_modes.cpp
+++ b/tests/core_channel_instances/test_can_switch_between_modes.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Start with blended mode
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+        AM_EXPECT(channel.GetInstancingMode() == eChannelInstanceMode_Blended);
+
+        // Add instances
+        AM_UNUSED(channel.AddInstance({ 100.0f, 0.0f, 50.0f }));
+        AM_UNUSED(channel.AddInstance({ 120.0f, 0.0f, 80.0f }));
+        AM_EXPECT(channel.GetInstanceCount() == 2);
+
+        // Switch to separate mode (note: this should clear existing instances based on implementation)
+        channel.DisableInstancing();
+        channel.EnableInstancing(eChannelInstanceMode_Separate);
+        AM_EXPECT(channel.GetInstancingMode() == eChannelInstanceMode_Separate);
+
+        // Add instances in separate mode
+        AM_UNUSED(channel.AddInstance({ 100.0f, 0.0f, 50.0f }));
+        AM_UNUSED(channel.AddInstance({ 120.0f, 0.0f, 80.0f }));
+        AM_UNUSED(channel.AddInstance({ 140.0f, 0.0f, 110.0f }));
+        AM_EXPECT(channel.GetInstanceCount() == 3);
+
+        // Switch back to blended mode
+        channel.DisableInstancing();
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+        AM_EXPECT(channel.GetInstancingMode() == eChannelInstanceMode_Blended);
+
+        // Verify channel is still playing
+        AM_EXPECT(channel.Playing());
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_cannot_add_instances_when_disabled.cpp
+++ b/tests/core_channel_instances/test_cannot_add_instances_when_disabled.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Instancing should be disabled initially
+        AM_EXPECT_NOT(channel.IsInstancingEnabled());
+
+        // Attempt to add an instance - should return invalid instance
+        ChannelInstance instance = channel.AddInstance({ 100.0f, 0.0f, 50.0f });
+        AM_EXPECT_NOT(instance.Valid());
+
+        // Instance count should remain 0
+        AM_EXPECT(channel.GetInstanceCount() == 0);
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_handles_empty_instance_list.cpp
+++ b/tests/core_channel_instances/test_handles_empty_instance_list.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Enable instancing without adding any instances
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+        AM_EXPECT(channel.GetInstanceCount() == 0);
+
+        // The channel should still be valid and playing
+        // (behavior with empty instance list should fall back to single-position)
+        AM_EXPECT(channel.Playing());
+
+        // Let the sound play
+        amEngine->WaitUntilFrames(10);
+
+        // Channel should still be playing
+        AM_EXPECT(channel.Playing());
+
+        // Test separate mode with empty instances as well
+        channel.DisableInstancing();
+        channel.EnableInstancing(eChannelInstanceMode_Separate);
+        AM_EXPECT(channel.GetInstanceCount() == 0);
+
+        // Should still be playing
+        AM_EXPECT(channel.Playing());
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_handles_removing_nonexistent_instance.cpp
+++ b/tests/core_channel_instances/test_handles_removing_nonexistent_instance.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Enable instancing
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+
+        // Add some instances
+        ChannelInstance instance1 = channel.AddInstance({ 100.0f, 0.0f, 50.0f });
+        ChannelInstance instance2 = channel.AddInstance({ 120.0f, 0.0f, 80.0f });
+
+        AM_EXPECT(channel.GetInstanceCount() == 2);
+
+        // Try to remove a non-existent instance - should not crash
+        channel.RemoveInstance(999999);
+
+        // Instance count should remain unchanged
+        AM_EXPECT(channel.GetInstanceCount() == 2);
+
+        // Try to remove the same instance twice
+        channel.RemoveInstance(instance1.GetId());
+        AM_EXPECT(channel.GetInstanceCount() == 1);
+
+        // Removing again should not crash or change count
+        channel.RemoveInstance(instance1.GetId());
+        AM_EXPECT(channel.GetInstanceCount() == 1);
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_handles_zero_weight_instances.cpp
+++ b/tests/core_channel_instances/test_handles_zero_weight_instances.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Enable blended mode
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+
+        // Add instances with zero weight
+        ChannelInstance instance1 = channel.AddInstance({ 100.0f, 0.0f, 50.0f });
+        instance1.SetWeight(0.0f);
+
+        ChannelInstance instance2 = channel.AddInstance({ 120.0f, 0.0f, 80.0f });
+        instance2.SetWeight(0.0f);
+
+        // Verify weights are set to zero
+        AM_EXPECT(std::abs(instance1.GetWeight() - 0.0f) < kEpsilon);
+        AM_EXPECT(std::abs(instance2.GetWeight() - 0.0f) < kEpsilon);
+
+        // The channel should still be valid and playing
+        // (though it may be silent due to zero total weight)
+        AM_EXPECT(channel.Playing());
+
+        // Add an instance with non-zero weight
+        ChannelInstance instance3 = channel.AddInstance({ 140.0f, 0.0f, 110.0f });
+        instance3.SetWeight(1.0f);
+
+        AM_EXPECT(std::abs(instance3.GetWeight() - 1.0f) < kEpsilon);
+
+        // Let the sound play
+        amEngine->WaitUntilFrames(10);
+
+        // Channel should still be playing
+        AM_EXPECT(channel.Playing());
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_instance_count_is_correct.cpp
+++ b/tests/core_channel_instances/test_instance_count_is_correct.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Enable instancing
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+
+        // Initial count should be 0
+        AM_EXPECT(channel.GetInstanceCount() == 0);
+
+        // Add multiple instances and verify count
+        for (AmSize i = 0; i < 10; ++i)
+        {
+            AM_UNUSED(channel.AddInstance({ static_cast<AmReal32>(i * 10.0f), 0.0f, 0.0f }));
+            AM_EXPECT(channel.GetInstanceCount() == i + 1);
+        }
+
+        // Remove instances and verify count
+        AmSize currentCount = channel.GetInstanceCount();
+        for (AmSize i = 0; i < 5; ++i)
+        {
+            ChannelInstance instance = channel.GetInstance(i + 1); // IDs start from 1
+            if (instance.Valid())
+            {
+                channel.RemoveInstance(instance.GetId());
+                currentCount--;
+                AM_EXPECT(channel.GetInstanceCount() == currentCount);
+            }
+        }
+
+        // Clear all instances
+        channel.ClearInstances();
+        AM_EXPECT(channel.GetInstanceCount() == 0);
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_instances_can_have_different_rooms.cpp
+++ b/tests/core_channel_instances/test_instances_can_have_different_rooms.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Create test rooms
+        Room room1 = amEngine->AddRoom(1);
+        Room room2 = amEngine->AddRoom(2);
+        Room room3 = amEngine->AddRoom(3);
+
+        AM_EXPECT(room1.Valid());
+        AM_EXPECT(room2.Valid());
+        AM_EXPECT(room3.Valid());
+
+        // Enable instancing
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+
+        // Add instances with different rooms
+        ChannelInstance instance1 = channel.AddInstance({ 100.0f, 0.0f, 50.0f });
+        instance1.SetRoom(room1);
+
+        ChannelInstance instance2 = channel.AddInstance({ 120.0f, 0.0f, 80.0f });
+        instance2.SetRoom(room2);
+
+        ChannelInstance instance3 = channel.AddInstance({ 140.0f, 0.0f, 110.0f });
+        instance3.SetRoom(room3);
+
+        // Verify each instance has the correct room
+        AM_EXPECT(instance1.GetRoom().Valid());
+        AM_EXPECT(instance1.GetRoom().GetId() == room1.GetId());
+
+        AM_EXPECT(instance2.GetRoom().Valid());
+        AM_EXPECT(instance2.GetRoom().GetId() == room2.GetId());
+
+        AM_EXPECT(instance3.GetRoom().Valid());
+        AM_EXPECT(instance3.GetRoom().GetId() == room3.GetId());
+
+        // Cleanup
+        amEngine->RemoveRoom(1);
+        amEngine->RemoveRoom(2);
+        amEngine->RemoveRoom(3);
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_instances_cleared_on_disable.cpp
+++ b/tests/core_channel_instances/test_instances_cleared_on_disable.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Enable instancing
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+
+        // Add instances
+        AM_UNUSED(channel.AddInstance({ 100.0f, 0.0f, 50.0f }));
+        AM_UNUSED(channel.AddInstance({ 120.0f, 0.0f, 80.0f }));
+        AM_UNUSED(channel.AddInstance({ 140.0f, 0.0f, 110.0f }));
+
+        AM_EXPECT(channel.GetInstanceCount() == 3);
+
+        // Disable instancing - should clear all instances
+        channel.DisableInstancing();
+        AM_EXPECT(channel.GetInstanceCount() == 0);
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_returns_invalid_instance_for_nonexistent_id.cpp
+++ b/tests/core_channel_instances/test_returns_invalid_instance_for_nonexistent_id.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Enable instancing
+        channel.EnableInstancing(eChannelInstanceMode_Blended);
+
+        // Try to get an instance with invalid ID
+        ChannelInstance invalidInstance = channel.GetInstance(999999);
+        AM_EXPECT(!invalidInstance.Valid());
+
+        // Add an instance
+        ChannelInstance validInstance = channel.AddInstance({ 100.0f, 0.0f, 50.0f });
+        AM_EXPECT(validInstance.Valid());
+
+        // Try to get the valid instance
+        ChannelInstance retrievedInstance = channel.GetInstance(validInstance.GetId());
+        AM_EXPECT(retrievedInstance.Valid());
+        AM_EXPECT(retrievedInstance.GetId() == validInstance.GetId());
+
+        // Remove the instance
+        channel.RemoveInstance(validInstance.GetId());
+
+        // Try to get the removed instance - should be invalid
+        ChannelInstance removedInstance = channel.GetInstance(validInstance.GetId());
+        AM_EXPECT(!removedInstance.Valid());
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_separate_mode_enables_correctly.cpp
+++ b/tests/core_channel_instances/test_separate_mode_enables_correctly.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    void EngineTestCase::Run()
+    {
+        SoundHandle test_sound_01 = amEngine->GetSoundHandle("test_sound_01");
+
+        Channel channel = amEngine->Play(test_sound_01);
+        amEngine->WaitUntilFrames(2);
+
+        AM_EXPECT(channel.Valid());
+
+        // Enable separate mode
+        channel.EnableInstancing(eChannelInstanceMode_Separate);
+        AM_EXPECT(channel.GetInstancingMode() == eChannelInstanceMode_Separate);
+
+        // Add multiple instances
+        AM_UNUSED(channel.AddInstance({ 100.0f, 0.0f, 50.0f }));
+        AM_UNUSED(channel.AddInstance({ 120.0f, 0.0f, 80.0f }));
+        AM_UNUSED(channel.AddInstance({ 140.0f, 0.0f, 110.0f }));
+
+        AM_EXPECT(channel.GetInstanceCount() == 3);
+
+        // In separate mode, each instance has independent playback cursor
+        // We can't directly test the cursor independence without accessing internal state,
+        // but we can verify that the channel is playing and the mode is correct
+        AM_EXPECT(channel.Playing());
+        AM_EXPECT(channel.GetInstancingMode() == eChannelInstanceMode_Separate);
+
+        // Advance a few frames to let the sound play
+        amEngine->WaitUntilFrames(10);
+
+        // Channel should still be playing
+        AM_EXPECT(channel.Playing());
+    }
+} // namespace SparkyStudios::Audio::Amplitude::Tests


### PR DESCRIPTION
Added instanced audio rendering feature, where a single sound object can be played in multiple positions, sharing the same sound data. An instanced sound object can be used in two modes:

- Blended mode allows all instances of a sound object to share the same cursor (playback position). The final sound position is a weighted virtual position (computed using instance's weight, gain and distance from listener), and that position is used for attenuation and ambisonic/stereo panning.
- Separate mode is useful when the instances should only share the same sound data. In separate mode, each instance is treated as a single sound object, where environmental effects, attenuation and panning are processed separately per instance.

In both modes, the overall playback (pause, stop, resume states) is managed by the parent channel, and affects all instances at the same time.