### PR TITLE
Performance improvements and thread safety fixes

### DIFF
--- a/include/SparkyStudios/Audio/Amplitude/Amplitude.h
+++ b/include/SparkyStudios/Audio/Amplitude/Amplitude.h
@@ -95,6 +95,7 @@
 #include <SparkyStudios/Audio/Amplitude/IO/File.h>
 #include <SparkyStudios/Audio/Amplitude/IO/FileSystem.h>
 #include <SparkyStudios/Audio/Amplitude/IO/Log.h>
+#include <SparkyStudios/Audio/Amplitude/IO/MappedFile.h>
 #include <SparkyStudios/Audio/Amplitude/IO/MemoryFile.h>
 #include <SparkyStudios/Audio/Amplitude/IO/NullLogger.h>
 #include <SparkyStudios/Audio/Amplitude/IO/PackageFileSystem.h>

--- a/include/SparkyStudios/Audio/Amplitude/Core/MPSCQueue.h
+++ b/include/SparkyStudios/Audio/Amplitude/Core/MPSCQueue.h
@@ -1,0 +1,208 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _AM_CORE_MPSCQUEUE_H
+#define _AM_CORE_MPSCQUEUE_H
+
+#include <atomic>
+
+#include <SparkyStudios/Audio/Amplitude/Core/Common.h>
+
+namespace SparkyStudios::Audio::Amplitude
+{
+    /**
+     * @brief Lock-free bounded multi-producer single-consumer queue.
+     *
+     * Based on Dmitry Vyukov's bounded MPMC queue, specialized for multiple
+     * producers and a single consumer. Each slot carries a sequence counter
+     * that coordinates producers via CAS on the tail index and lets the
+     * single consumer advance the head without contention.
+     *
+     * The tail (producers) and head (consumer) are aligned to separate cache
+     * lines to prevent false sharing.
+     *
+     * @tparam T The element type.
+     * @tparam Capacity Queue capacity. Must be a power of 2. Default is 256.
+     *
+     * @ingroup core
+     */
+    template<typename T, AmSize Capacity = 256>
+    class MPSCQueue
+    {
+        static_assert((Capacity & (Capacity - 1)) == 0, "Capacity must be a power of 2");
+        static_assert(Capacity > 0, "Capacity must be greater than 0");
+
+    public:
+        /**
+         * @brief Constructs an empty queue.
+         *
+         * Initializes every slot's sequence to its index so that the first
+         * Capacity enqueues can proceed without waiting.
+         */
+        MPSCQueue()
+            : _tail(0)
+            , _head(0)
+        {
+            for (AmSize i = 0; i < Capacity; ++i)
+                _buffer[i].sequence.store(i, std::memory_order_relaxed);
+        }
+
+        ~MPSCQueue() = default;
+
+        MPSCQueue(const MPSCQueue&) = delete;
+        MPSCQueue& operator=(const MPSCQueue&) = delete;
+
+        /**
+         * @brief Attempts to enqueue an item by copy (multi-producer safe).
+         *
+         * @param[in] item The item to enqueue.
+         * @return @c true if enqueued, @c false if the queue is full.
+         */
+        bool TryEnqueue(const T& item)
+        {
+            Cell* cell;
+            AmSize pos = _tail.load(std::memory_order_relaxed);
+
+            for (;;)
+            {
+                cell = &_buffer[pos & kMask];
+                const AmSize seq = cell->sequence.load(std::memory_order_acquire);
+                const auto diff = static_cast<std::ptrdiff_t>(seq) - static_cast<std::ptrdiff_t>(pos);
+
+                if (diff == 0)
+                {
+                    // Slot is free — try to claim it
+                    if (_tail.compare_exchange_weak(pos, pos + 1, std::memory_order_relaxed))
+                        break;
+                }
+                else if (diff < 0)
+                {
+                    // Queue is full
+                    return false;
+                }
+                else
+                {
+                    // Another producer claimed this slot, reload tail
+                    pos = _tail.load(std::memory_order_relaxed);
+                }
+            }
+
+            cell->data = item;
+            cell->sequence.store(pos + 1, std::memory_order_release);
+            return true;
+        }
+
+        /**
+         * @brief Attempts to enqueue an item by move (multi-producer safe).
+         *
+         * @param[in] item The item to enqueue.
+         * @return @c true if enqueued, @c false if the queue is full.
+         */
+        bool TryEnqueue(T&& item)
+        {
+            Cell* cell;
+            AmSize pos = _tail.load(std::memory_order_relaxed);
+
+            for (;;)
+            {
+                cell = &_buffer[pos & kMask];
+                const AmSize seq = cell->sequence.load(std::memory_order_acquire);
+                const auto diff = static_cast<std::ptrdiff_t>(seq) - static_cast<std::ptrdiff_t>(pos);
+
+                if (diff == 0)
+                {
+                    if (_tail.compare_exchange_weak(pos, pos + 1, std::memory_order_relaxed))
+                        break;
+                }
+                else if (diff < 0)
+                {
+                    return false;
+                }
+                else
+                {
+                    pos = _tail.load(std::memory_order_relaxed);
+                }
+            }
+
+            cell->data = std::move(item);
+            cell->sequence.store(pos + 1, std::memory_order_release);
+            return true;
+        }
+
+        /**
+         * @brief Attempts to dequeue an item.
+         *
+         * @param[out] item Receives the dequeued item on success.
+         * @return @c true if an item was dequeued, @c false if the queue is empty.
+         *
+         * @note Must only be called from the single consumer thread.
+         */
+        bool TryDequeue(T& item)
+        {
+            Cell* cell = &_buffer[_head & kMask];
+            const AmSize seq = cell->sequence.load(std::memory_order_acquire);
+            const auto diff = static_cast<std::ptrdiff_t>(seq) - static_cast<std::ptrdiff_t>(_head + 1);
+
+            if (diff < 0)
+                return false; // Queue is empty
+
+            item = std::move(cell->data);
+            cell->sequence.store(_head + Capacity, std::memory_order_release);
+            ++_head;
+            return true;
+        }
+
+        /**
+         * @brief Checks if the queue is empty.
+         *
+         * @return @c true if empty.
+         *
+         * @note The result is a snapshot and may be stale immediately.
+         */
+        [[nodiscard]] bool IsEmpty() const
+        {
+            const Cell& cell = _buffer[_head & kMask];
+            const AmSize seq = cell.sequence.load(std::memory_order_acquire);
+            const auto diff = static_cast<std::ptrdiff_t>(seq) - static_cast<std::ptrdiff_t>(_head + 1);
+            return diff < 0;
+        }
+
+        /**
+         * @brief Gets the queue capacity (maximum storable items).
+         *
+         * @return The queue capacity.
+         */
+        [[nodiscard]] static constexpr AmSize GetCapacity()
+        {
+            return Capacity;
+        }
+
+    private:
+        static constexpr AmSize kCacheLineSize = 64;
+        static constexpr AmSize kMask = Capacity - 1;
+
+        struct Cell
+        {
+            std::atomic<AmSize> sequence;
+            T data;
+        };
+
+        alignas(kCacheLineSize) Cell _buffer[Capacity];
+        alignas(kCacheLineSize) std::atomic<AmSize> _tail;
+        alignas(kCacheLineSize) AmSize _head; // Consumer-only, no atomic needed
+    };
+
+} // namespace SparkyStudios::Audio::Amplitude
+
+#endif // _AM_CORE_MPSCQUEUE_H

--- a/include/SparkyStudios/Audio/Amplitude/Core/Memory.h
+++ b/include/SparkyStudios/Audio/Amplitude/Core/Memory.h
@@ -20,10 +20,11 @@
 #include <SparkyStudios/Audio/Amplitude/Core/Common.h>
 
 #include <memory>
-#include <set>
 
 #if !defined(AM_NO_MEMORY_STATS)
 #include <atomic>
+#include <mutex>
+#include <set>
 #include <unordered_map>
 #endif
 
@@ -708,6 +709,17 @@ namespace SparkyStudios::Audio::Amplitude
         void Free(eMemoryPoolKind pool, AmVoidPtr address);
 
         /**
+         * @brief Gets the size of the given memory block.
+         *
+         * @param[in] pool The memory pool to get the size from.
+         * @param[in] address The address of the memory block.
+         *
+         * @return The size of the given memory block.
+         */
+        [[nodiscard]] AmSize SizeOf(eMemoryPoolKind pool, AmVoidPtr address) const;
+
+#if !defined(AM_NO_MEMORY_STATS)
+        /**
          * @brief Gets the total allocated size of the specified pool.
          *
          * @param[in] pool The memory pool to get the total allocated size from.
@@ -723,17 +735,6 @@ namespace SparkyStudios::Audio::Amplitude
          */
         [[nodiscard]] AmSize TotalReservedMemorySize() const;
 
-        /**
-         * @brief Gets the size of the given memory block.
-         *
-         * @param[in] pool The memory pool to get the size from.
-         * @param[in] address The address of the memory block.
-         *
-         * @return The size of the given memory block.
-         */
-        [[nodiscard]] AmSize SizeOf(eMemoryPoolKind pool, AmVoidPtr address) const;
-
-#if !defined(AM_NO_MEMORY_STATS)
         /**
          * @brief Gets the name of the given memory pool.
          *
@@ -765,14 +766,14 @@ namespace SparkyStudios::Audio::Amplitude
         explicit MemoryManager(std::unique_ptr<MemoryAllocator> allocator);
         ~MemoryManager();
 
+        std::unique_ptr<MemoryAllocator> _allocator;
+
+#if !defined(AM_NO_MEMORY_STATS)
         void RemoveAllocation(const Allocation& allocation);
         void AddAllocation(const Allocation& allocation);
 
-        std::unique_ptr<MemoryAllocator> _allocator;
-
+        mutable std::mutex _allocationsMutex;
         std::set<Allocation> _memAllocations;
-
-#if !defined(AM_NO_MEMORY_STATS)
         std::unordered_map<eMemoryPoolKind, MemoryPoolStats> _memPoolsStats;
 #endif
     };

--- a/include/SparkyStudios/Audio/Amplitude/Core/SPSCQueue.h
+++ b/include/SparkyStudios/Audio/Amplitude/Core/SPSCQueue.h
@@ -1,0 +1,158 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _AM_CORE_SPSCQUEUE_H
+#define _AM_CORE_SPSCQUEUE_H
+
+#include <atomic>
+
+#include <SparkyStudios/Audio/Amplitude/Core/Common.h>
+
+namespace SparkyStudios::Audio::Amplitude
+{
+    /**
+     * @brief Lock-free single-producer single-consumer queue.
+     *
+     * Provides wait-free enqueue (producer) and dequeue (consumer) operations
+     * for exactly one producer thread and one consumer thread. No locks are used;
+     * synchronization relies solely on atomic head/tail indices with acquire/release
+     * memory ordering.
+     *
+     * The head and tail indices are aligned to separate cache lines to prevent
+     * false sharing between the producer and consumer.
+     *
+     * @tparam T The element type.
+     * @tparam Capacity Queue capacity. Must be a power of 2. Default is 256.
+     *
+     * @ingroup core
+     */
+    template<typename T, AmSize Capacity = 256>
+    class SPSCQueue
+    {
+        static_assert((Capacity & (Capacity - 1)) == 0, "Capacity must be a power of 2");
+        static_assert(Capacity > 0, "Capacity must be greater than 0");
+
+    public:
+        /**
+         * @brief Constructs an empty queue.
+         */
+        SPSCQueue()
+            : _head(0)
+            , _tail(0)
+        {}
+
+        ~SPSCQueue() = default;
+
+        SPSCQueue(const SPSCQueue&) = delete;
+        SPSCQueue& operator=(const SPSCQueue&) = delete;
+
+        /**
+         * @brief Attempts to enqueue an item by copy.
+         *
+         * @param[in] item The item to enqueue.
+         * @return @c true if enqueued, @c false if the queue is full.
+         *
+         * @note Must only be called from the producer thread.
+         */
+        bool TryEnqueue(const T& item)
+        {
+            const AmSize tail = _tail.load(std::memory_order_relaxed);
+            const AmSize nextTail = (tail + 1) & kMask;
+
+            if (nextTail == _head.load(std::memory_order_acquire))
+                return false;
+
+            _buffer[tail] = item;
+            _tail.store(nextTail, std::memory_order_release);
+            return true;
+        }
+
+        /**
+         * @brief Attempts to enqueue an item by move.
+         *
+         * @param[in] item The item to enqueue.
+         * @return @c true if enqueued, @c false if the queue is full.
+         *
+         * @note Must only be called from the producer thread.
+         */
+        bool TryEnqueue(T&& item)
+        {
+            const AmSize tail = _tail.load(std::memory_order_relaxed);
+            const AmSize nextTail = (tail + 1) & kMask;
+
+            if (nextTail == _head.load(std::memory_order_acquire))
+                return false;
+
+            _buffer[tail] = std::move(item);
+            _tail.store(nextTail, std::memory_order_release);
+            return true;
+        }
+
+        /**
+         * @brief Attempts to dequeue an item.
+         *
+         * @param[out] item Receives the dequeued item on success.
+         * @return @c true if an item was dequeued, @c false if the queue is empty.
+         *
+         * @note Must only be called from the consumer thread.
+         */
+        bool TryDequeue(T& item)
+        {
+            const AmSize head = _head.load(std::memory_order_relaxed);
+
+            if (head == _tail.load(std::memory_order_acquire))
+                return false;
+
+            item = std::move(_buffer[head]);
+            _head.store((head + 1) & kMask, std::memory_order_release);
+            return true;
+        }
+
+        /**
+         * @brief Checks if the queue is empty.
+         *
+         * @return @c true if empty.
+         *
+         * @note The result is a snapshot and may be stale immediately.
+         */
+        [[nodiscard]] bool IsEmpty() const
+        {
+            return _head.load(std::memory_order_relaxed) == _tail.load(std::memory_order_relaxed);
+        }
+
+        /**
+         * @brief Gets the queue capacity (maximum storable items).
+         *
+         * One slot is reserved internally for full/empty disambiguation, so the
+         * usable capacity is @c Capacity - 1.
+         *
+         * @return The usable queue capacity.
+         */
+        [[nodiscard]] static constexpr AmSize GetCapacity()
+        {
+            return Capacity - 1;
+        }
+
+    private:
+        static constexpr AmSize kCacheLineSize = 64;
+        static constexpr AmSize kMask = Capacity - 1;
+
+        alignas(kCacheLineSize) std::atomic<AmSize> _head;
+        alignas(kCacheLineSize) std::atomic<AmSize> _tail;
+        alignas(kCacheLineSize) T _buffer[Capacity];
+    };
+
+} // namespace SparkyStudios::Audio::Amplitude
+
+#endif // _AM_CORE_SPSCQUEUE_H

--- a/include/SparkyStudios/Audio/Amplitude/DSP/AudioConverter.h
+++ b/include/SparkyStudios/Audio/Amplitude/DSP/AudioConverter.h
@@ -169,6 +169,8 @@ namespace SparkyStudios::Audio::Amplitude
         bool _srcInitialized;
 
         Settings _settings;
+
+        AudioBuffer _tempBuffer;
     };
 } // namespace SparkyStudios::Audio::Amplitude
 

--- a/include/SparkyStudios/Audio/Amplitude/IO/DiskFile.h
+++ b/include/SparkyStudios/Audio/Amplitude/IO/DiskFile.h
@@ -17,8 +17,6 @@
 #ifndef _AM_IO_DISK_FILE_H
 #define _AM_IO_DISK_FILE_H
 
-#include <filesystem>
-
 #include <SparkyStudios/Audio/Amplitude/IO/File.h>
 
 #include <filesystem>

--- a/include/SparkyStudios/Audio/Amplitude/IO/MappedFile.h
+++ b/include/SparkyStudios/Audio/Amplitude/IO/MappedFile.h
@@ -1,0 +1,139 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifndef _AM_IO_MAPPED_FILE_H
+#define _AM_IO_MAPPED_FILE_H
+
+#include <SparkyStudios/Audio/Amplitude/IO/File.h>
+
+#include <filesystem>
+
+namespace SparkyStudios::Audio::Amplitude
+{
+    /**
+     * @brief A @ref File implementation that uses memory-mapped I/O for efficient read-only file access.
+     *
+     * On desktop platforms (Windows, Linux, macOS), files larger than or equal to 1 MB are memory-mapped
+     * using platform-native APIs (mmap on POSIX, CreateFileMapping on Windows). For smaller files or when
+     * memory mapping is unavailable, the file is loaded into a heap-allocated buffer.
+     *
+     * @note This implementation is read-only. @ref Write operations return 0.
+     *
+     * @ingroup io
+     */
+    class AM_API_PUBLIC MappedFile : public File
+    {
+    public:
+        /**
+         * @brief Creates a new @c MappedFile instance.
+         */
+        MappedFile();
+
+        /**
+         * @brief Creates a new @c MappedFile instance by opening a file at the given path.
+         *
+         * @param[in] fileName The path to the file to open.
+         */
+        explicit MappedFile(const std::filesystem::path& fileName);
+
+        /**
+         * @brief Destroys the instance and releases the memory mapping or heap buffer.
+         */
+        ~MappedFile() override;
+
+        /**
+         * @inherit
+         */
+        [[nodiscard]] AmOsString GetPath() const override;
+
+        /**
+         * @inherit
+         */
+        [[nodiscard]] bool Eof() const override;
+
+        /**
+         * @inherit
+         */
+        AmSize Read(AmUInt8Buffer dst, AmSize bytes) const override;
+
+        /**
+         * @brief Write is not supported for memory-mapped files.
+         *
+         * @return Always returns 0.
+         */
+        AmSize Write(AmConstUInt8Buffer src, AmSize bytes) override;
+
+        /**
+         * @inherit
+         */
+        [[nodiscard]] AmSize Length() const override;
+
+        /**
+         * @inherit
+         */
+        void Seek(AmInt64 offset, eFileSeekOrigin origin) override;
+
+        /**
+         * @inherit
+         */
+        [[nodiscard]] AmSize Position() const override;
+
+        /**
+         * @inherit
+         */
+        [[nodiscard]] AmVoidPtr GetPtr() const override;
+
+        /**
+         * @inherit
+         */
+        [[nodiscard]] bool IsValid() const override;
+
+        /**
+         * @inherit
+         */
+        void Close() override;
+
+        /**
+         * @brief Opens a file using memory mapping or heap-based fallback.
+         *
+         * Files larger than or equal to 1 MB are memory-mapped on supported desktop platforms.
+         * Smaller files, or files on unsupported platforms, are loaded into a heap buffer.
+         *
+         * @param[in] filePath The path to the file to open.
+         *
+         * @return The result of the operation.
+         */
+        AmResult Open(const std::filesystem::path& filePath);
+
+        /**
+         * @brief Checks whether this file is backed by a memory mapping.
+         *
+         * @return @c true if memory-mapped, @c false if using heap-based fallback.
+         */
+        [[nodiscard]] bool IsMapped() const;
+
+    private:
+        std::filesystem::path m_filePath;
+        AmUInt8Buffer m_dataPtr;
+        AmSize m_dataSize;
+        mutable AmSize m_offset;
+        bool m_isMapped;
+        bool m_dataOwned;
+        AmVoidPtr m_mapHandle;
+    };
+} // namespace SparkyStudios::Audio::Amplitude
+
+#endif // _AM_IO_MAPPED_FILE_H

--- a/include/SparkyStudios/Audio/Amplitude/IO/PackageItemFile.h
+++ b/include/SparkyStudios/Audio/Amplitude/IO/PackageItemFile.h
@@ -107,6 +107,12 @@ namespace SparkyStudios::Audio::Amplitude
         const bool _isCompressed;
         const AmSize _headerSize;
         mutable AmInt64 _currentPosition;
+
+        mutable AmUInt8* _compressedBuffer;
+        mutable AmSize _compressedBufferCapacity;
+        mutable AmUInt8* _decompressedBuffer;
+        mutable AmSize _decompressedBufferCapacity;
+        mutable AmSize _cachedChunkIndex;
     };
 } // namespace SparkyStudios::Audio::Amplitude
 

--- a/include/SparkyStudios/Audio/Amplitude/Mixer/Node.h
+++ b/include/SparkyStudios/Audio/Amplitude/Mixer/Node.h
@@ -324,6 +324,7 @@ namespace SparkyStudios::Audio::Amplitude
         const AudioBuffer* _processingBuffer;
         const AudioBuffer* _lastOutputBuffer;
         bool _processOnEmptyInputBuffer;
+        ProviderNodeInstance* _cachedProvider;
     };
 
     /**
@@ -420,6 +421,7 @@ namespace SparkyStudios::Audio::Amplitude
     private:
         std::vector<const AudioBuffer*> _processingBuffers;
         bool _processed;
+        std::vector<ProviderNodeInstance*> _cachedProviders;
     };
 
     /**
@@ -523,6 +525,7 @@ namespace SparkyStudios::Audio::Amplitude
     private:
         AmObjectID _provider;
         AudioBuffer* _buffer;
+        ProviderNodeInstance* _cachedProvider;
     };
 
     /**

--- a/include/SparkyStudios/Audio/Amplitude/Mixer/Pipeline.h
+++ b/include/SparkyStudios/Audio/Amplitude/Mixer/Pipeline.h
@@ -46,11 +46,11 @@ namespace SparkyStudios::Audio::Amplitude
         /**
          * @brief Executes the pipeline for the given layer.
          *
-         * @param[in] in The input buffer to process. This buffer is passed to the input
-         * node of the pipeline.
+         * @param[in,out] in The input buffer to process. This buffer may be modified in-place
+         * by the input node's filter. It is passed to the input node of the pipeline.
          * @param[out] out The output buffer where the output node will fill processed data.
          */
-        virtual void Execute(const AudioBuffer& in, AudioBuffer& out) = 0;
+        virtual void Execute(AudioBuffer& in, AudioBuffer& out) = 0;
 
         /**
          * @brief Resets the internal state for all nodes in the pipeline.

--- a/include/SparkyStudios/Audio/Amplitude/Sound/Collection.h
+++ b/include/SparkyStudios/Audio/Amplitude/Sound/Collection.h
@@ -17,6 +17,8 @@
 #ifndef _AM_SOUND_COLLECTION_H
 #define _AM_SOUND_COLLECTION_H
 
+#include <unordered_set>
+
 #include <SparkyStudios/Audio/Amplitude/Core/Entity.h>
 
 #include <SparkyStudios/Audio/Amplitude/Sound/Sound.h>
@@ -48,7 +50,7 @@ namespace SparkyStudios::Audio::Amplitude
          *
          * @return The selected Sound.
          */
-        [[nodiscard]] virtual Sound* SelectFromWorld(const std::vector<AmSoundID>& toSkip) const = 0;
+        [[nodiscard]] virtual Sound* SelectFromWorld(const std::unordered_set<AmSoundID>& toSkip) const = 0;
 
         /**
          * @brief Returns a Sound from this collection from an Entity scope.
@@ -60,7 +62,7 @@ namespace SparkyStudios::Audio::Amplitude
          *
          * @return The selected Sound.
          */
-        virtual Sound* SelectFromEntity(const Entity& entity, const std::vector<AmSoundID>& toSkip) = 0;
+        virtual Sound* SelectFromEntity(const Entity& entity, const std::unordered_set<AmSoundID>& toSkip) = 0;
 
         /**
          * @brief Resets the internal state of the scheduler running for the given Entity.

--- a/samples/sample_01/main.cpp
+++ b/samples/sample_01/main.cpp
@@ -316,7 +316,7 @@ static void run(AmVoidPtr param)
 
 int main(int argc, char* argv[])
 {
-#if defined(_DEBUG) || defined(DEBUG) || (defined(__GNUC__) && !defined(__OPTIMIZE__))
+#ifdef AM_DEBUG
     ConsoleLogger logger(true);
 #else
     ConsoleLogger logger(false);

--- a/src/Core/Engine.cpp
+++ b/src/Core/Engine.cpp
@@ -767,9 +767,8 @@ namespace SparkyStudios::Audio::Amplitude
 
         if (_audioDriver == nullptr)
         {
-            amLogCritical(
-                "Failed to load the specified driver, the default driver, and the null driver. Please check your engine "
-                "configuration, and ensure that all the needed plugins are loaded.");
+            amLogCritical("Failed to load the specified driver, the default driver, and the null driver. Please check your engine "
+                          "configuration, and ensure that all the needed plugins are loaded.");
             Deinitialize();
             return false;
         }
@@ -800,9 +799,8 @@ namespace SparkyStudios::Audio::Amplitude
         }
         else if (_state->panning_mode != ePanningMode_Stereo)
         {
-            amLogCritical(
-                "The HRTF configuration is missing, but the panning mode is not stereo. Please provide an HRTF configuration, or "
-                "set the panning mode to Stereo.");
+            amLogCritical("The HRTF configuration is missing, but the panning mode is not stereo. Please provide an HRTF configuration, or "
+                          "set the panning mode to Stereo.");
             Deinitialize();
             return false;
         }

--- a/src/Core/Engine.cpp
+++ b/src/Core/Engine.cpp
@@ -2478,18 +2478,13 @@ namespace SparkyStudios::Audio::Amplitude
         // before the best listener is selected.
         _state->listenerCache.Clear();
 
-        if (!_state->stopping)
         {
             std::lock_guard lock(_frameThreadMutex);
 
             // Execute pending frame callbacks.
-            while (!_nextFrameCallbacks.empty())
-            {
-                const auto& callback = _nextFrameCallbacks.front();
+            std::function<void(AmTime)> callback;
+            while (_nextFrameCallbacks.TryDequeue(callback))
                 callback(delta);
-
-                _nextFrameCallbacks.pop();
-            }
         }
 
         EraseFinishedSounds(_state);
@@ -2592,7 +2587,7 @@ namespace SparkyStudios::Audio::Amplitude
     void EngineImpl::OnNextFrame(std::function<void(AmTime delta)> callback) const
     {
         std::lock_guard lock(_frameThreadMutex);
-        _nextFrameCallbacks.push(std::move(callback));
+        _nextFrameCallbacks.TryEnqueue(std::move(callback));
     }
 
     void EngineImpl::WaitUntilNextFrame() const

--- a/src/Core/Engine.h
+++ b/src/Core/Engine.h
@@ -18,6 +18,7 @@
 #define _AM_IMPLEMENTATION_CORE_ENGINE_H
 
 #include <SparkyStudios/Audio/Amplitude/Core/Engine.h>
+#include <SparkyStudios/Audio/Amplitude/Core/MPSCQueue.h>
 
 #include <Core/EngineInternalState.h>
 
@@ -219,11 +220,11 @@ namespace SparkyStudios::Audio::Amplitude
         // The list of paths in which search for plugins.
         static std::set<AmOsString> _pluginSearchPaths;
 
-        mutable std::mutex _frameThreadMutex;
+        mutable std::recursive_mutex _frameThreadMutex;
         mutable std::recursive_mutex _updateMutex;
 
         // The list of pending next frame callbacks.
-        mutable std::queue<std::function<void(AmTime)>> _nextFrameCallbacks;
+        mutable MPSCQueue<std::function<void(AmTime)>, 1024> _nextFrameCallbacks;
 
         // The path to the config file.
         AmOsString _configFilePath;

--- a/src/Core/Memory.cpp
+++ b/src/Core/Memory.cpp
@@ -148,8 +148,8 @@ namespace SparkyStudios::Audio::Amplitude
 
     MemoryManager::MemoryManager(std::unique_ptr<MemoryAllocator> allocator)
         : _allocator(std::move(allocator))
-        , _memAllocations()
 #if !defined(AM_NO_MEMORY_STATS)
+        , _memAllocations()
         , _memPoolsStats()
 #endif
     {
@@ -159,64 +159,73 @@ namespace SparkyStudios::Audio::Amplitude
 
     MemoryManager::~MemoryManager()
     {
+#if !defined(AM_NO_MEMORY_STATS)
         // Clear the allocations set to prevent container leak
         _memAllocations.clear();
+#endif
 
         _allocator.reset(nullptr);
     }
 
+#if !defined(AM_NO_MEMORY_STATS)
     void MemoryManager::RemoveAllocation(const Allocation& allocation)
     {
+        std::lock_guard<std::mutex> lock(_allocationsMutex);
         if (const auto& it = _memAllocations.find(allocation); it != _memAllocations.end())
             _memAllocations.erase(it);
     }
 
     void MemoryManager::AddAllocation(const Allocation& allocation)
     {
+        std::lock_guard<std::mutex> lock(_allocationsMutex);
         _memAllocations.insert(allocation);
     }
+#endif
 
     AmVoidPtr MemoryManager::Malloc(eMemoryPoolKind pool, AmSize size, const char* file, AmUInt32 line)
     {
+        AmVoidPtr ptr = _allocator->Malloc(pool, size);
+
 #if !defined(AM_NO_MEMORY_STATS)
         _memPoolsStats[pool].maxMemoryUsed.fetch_add(size, std::memory_order_relaxed);
         _memPoolsStats[pool].allocCount.fetch_add(1, std::memory_order_relaxed);
+        AddAllocation({ pool, ptr, SizeOf(pool, ptr), file, line });
 #endif
 
-        AmVoidPtr ptr = _allocator->Malloc(pool, size);
-
-        AddAllocation({ pool, ptr, SizeOf(pool, ptr), file, line });
         return ptr;
     }
 
     AmVoidPtr MemoryManager::Malign(eMemoryPoolKind pool, AmSize size, AmUInt32 alignment, const char* file, AmUInt32 line)
     {
+        AmVoidPtr ptr = _allocator->Malign(pool, size, alignment);
+
 #if !defined(AM_NO_MEMORY_STATS)
         _memPoolsStats[pool].maxMemoryUsed.fetch_add(size, std::memory_order_relaxed);
         _memPoolsStats[pool].allocCount.fetch_add(1, std::memory_order_relaxed);
-#endif
-
-        AmVoidPtr ptr = _allocator->Malign(pool, size, alignment);
-
         AddAllocation({ pool, ptr, SizeOf(pool, ptr), file, line });
+#endif
 
         return ptr;
     }
 
     AmVoidPtr MemoryManager::Realloc(eMemoryPoolKind pool, AmVoidPtr address, AmSize size, const char* file, AmUInt32 line)
     {
+        AmVoidPtr ptr = _allocator->Realloc(pool, address, size);
+
 #if !defined(AM_NO_MEMORY_STATS)
         if (address == nullptr)
         {
             _memPoolsStats[pool].maxMemoryUsed.fetch_add(size, std::memory_order_relaxed);
             _memPoolsStats[pool].allocCount.fetch_add(1, std::memory_order_relaxed);
         }
+
+        {
+            std::lock_guard<std::mutex> lock(_allocationsMutex);
+            if (const auto& it = _memAllocations.find({ pool, address }); it != _memAllocations.end())
+                _memAllocations.erase(it);
+            _memAllocations.insert({ pool, ptr, SizeOf(pool, ptr), file, line });
+        }
 #endif
-
-        AmVoidPtr ptr = _allocator->Realloc(pool, address, size);
-
-        RemoveAllocation({ pool, address });
-        AddAllocation({ pool, ptr, SizeOf(pool, ptr), file, line });
 
         return ptr;
     }
@@ -224,35 +233,45 @@ namespace SparkyStudios::Audio::Amplitude
     AmVoidPtr MemoryManager::Realign(
         eMemoryPoolKind pool, AmVoidPtr address, AmSize size, AmUInt32 alignment, const char* file, AmUInt32 line)
     {
+        AmVoidPtr ptr = _allocator->Realign(pool, address, size, alignment);
+
 #if !defined(AM_NO_MEMORY_STATS)
         if (address == nullptr)
         {
             _memPoolsStats[pool].maxMemoryUsed.fetch_add(size, std::memory_order_relaxed);
             _memPoolsStats[pool].allocCount.fetch_add(1, std::memory_order_relaxed);
         }
+
+        {
+            std::lock_guard<std::mutex> lock(_allocationsMutex);
+            if (const auto& it = _memAllocations.find({ pool, address }); it != _memAllocations.end())
+                _memAllocations.erase(it);
+            _memAllocations.insert({ pool, ptr, SizeOf(pool, ptr), file, line });
+        }
 #endif
-
-        AmVoidPtr ptr = _allocator->Realign(pool, address, size, alignment);
-
-        RemoveAllocation({ pool, address });
-        AddAllocation({ pool, ptr, SizeOf(pool, ptr), file, line });
 
         return ptr;
     }
 
     void MemoryManager::Free(eMemoryPoolKind pool, AmVoidPtr address)
     {
-#if !defined(AM_NO_MEMORY_STATS)
-        _memPoolsStats[pool].freeCount.fetch_add(1, std::memory_order_relaxed);
-#endif
-
         _allocator->Free(pool, address);
 
+#if !defined(AM_NO_MEMORY_STATS)
+        _memPoolsStats[pool].freeCount.fetch_add(1, std::memory_order_relaxed);
         RemoveAllocation({ pool, address });
+#endif
     }
 
+    AmSize MemoryManager::SizeOf(eMemoryPoolKind pool, AmVoidPtr address) const
+    {
+        return _allocator->SizeOf(pool, address);
+    }
+
+#if !defined(AM_NO_MEMORY_STATS)
     AmSize MemoryManager::TotalReservedMemorySize(eMemoryPoolKind pool) const
     {
+        std::lock_guard<std::mutex> lock(_allocationsMutex);
         AmSize total = 0;
         for (const auto& allocation : _memAllocations)
             if (allocation.pool == pool)
@@ -263,6 +282,7 @@ namespace SparkyStudios::Audio::Amplitude
 
     AmSize MemoryManager::TotalReservedMemorySize() const
     {
+        std::lock_guard<std::mutex> lock(_allocationsMutex);
         AmSize total = 0;
         for (const auto& allocation : _memAllocations)
             total += allocation.size;
@@ -270,12 +290,6 @@ namespace SparkyStudios::Audio::Amplitude
         return total;
     }
 
-    AmSize MemoryManager::SizeOf(eMemoryPoolKind pool, AmVoidPtr address) const
-    {
-        return _allocator->SizeOf(pool, address);
-    }
-
-#if !defined(AM_NO_MEMORY_STATS)
     AmString MemoryManager::GetMemoryPoolName(const eMemoryPoolKind pool)
     {
         static std::unordered_map<eMemoryPoolKind, std::string> gMemoryPoolNames = {
@@ -297,6 +311,8 @@ namespace SparkyStudios::Audio::Amplitude
 
     AmString MemoryManager::InspectMemoryLeaks() const
     {
+        std::lock_guard<std::mutex> lock(_allocationsMutex);
+
         if (_memAllocations.empty())
             return "No memory leaks detected";
 

--- a/src/Core/Playback/ChannelInternalState.cpp
+++ b/src/Core/Playback/ChannelInternalState.cpp
@@ -44,12 +44,8 @@ namespace SparkyStudios::Audio::Amplitude
 
     void ChannelInternalState::Reset()
     {
-        _realChannel._channelLayersId.clear();
-        _realChannel._activeSounds.clear();
+        _realChannel._layers.clear();
         _realChannel._playedSounds.clear();
-        _realChannel._stream.clear();
-        _realChannel._loop.clear();
-        _realChannel._gain.clear();
 
         _dopplerFactors.clear();
         _channelState = eChannelPlaybackState_Stopped;
@@ -319,7 +315,7 @@ namespace SparkyStudios::Audio::Amplitude
         if (Playing())
         {
             // Resume playing the audio.
-            if (!_realChannel._channelLayersId.empty())
+            if (!_realChannel._layers.empty())
             {
                 Play();
             }
@@ -460,8 +456,8 @@ namespace SparkyStudios::Audio::Amplitude
 
                 // Build a map for faster layer lookup
                 std::unordered_map<AmObjectID, AmUInt32> soundToLayer;
-                for (const auto& [layerId, sound] : _realChannel._activeSounds)
-                    soundToLayer[sound->GetSettings().m_id] = layerId;
+                for (const auto& [layerId, layerData] : _realChannel._layers)
+                    soundToLayer[layerData.soundInstance->GetSettings().m_id] = layerId;
 
                 bool isAtLeastOneFadeInRunning = false;
                 bool isAtLeastOneFadeOutRunning = false;
@@ -863,7 +859,7 @@ namespace SparkyStudios::Audio::Amplitude
 
         // For separate mode, initialize cursor at 0 if channel is already playing
         // This allows instances to start at different points in time
-        if (_instancingMode == eChannelInstanceMode_Separate && !_realChannel._channelLayersId.empty())
+        if (_instancingMode == eChannelInstanceMode_Separate && !_realChannel._layers.empty())
             instance->SetCursor(0);
 
         _instances.push_back(*instance);

--- a/src/DSP/AudioConverter.cpp
+++ b/src/DSP/AudioConverter.cpp
@@ -56,34 +56,41 @@ namespace SparkyStudios::Audio::Amplitude
 
         _settings = settings;
 
+        // Pre-allocate the temp buffer for channel conversion
+        if (_channelConversionMode == kChannelConversionModeMonoToStereo)
+            _tempBuffer = AudioBuffer(kAmMaxSupportedFrameCount, 2);
+        else if (_channelConversionMode == kChannelConversionModeStereoToMono)
+            _tempBuffer = AudioBuffer(kAmMaxSupportedFrameCount, 1);
+
         return true;
     }
 
     void AudioConverter::Process(const AudioBuffer& input, AmUInt64& inputFrames, AudioBuffer& output, AmUInt64& outputFrames)
     {
-        AudioBuffer temp;
         if (_channelConversionMode == kChannelConversionModeDisabled)
         {
-            // No channel conversion required, just copy the input to the output.
-            temp = input;
-        }
-        else if (_channelConversionMode == kChannelConversionModeMonoToStereo)
-        {
-            temp = AudioBuffer(input.GetFrameCount(), 2);
-            ConvertStereoFromMono(input, temp);
-        }
-        else if (_channelConversionMode == kChannelConversionModeStereoToMono)
-        {
-            temp = AudioBuffer(input.GetFrameCount(), 1);
-            ConvertMonoFromStereo(input, temp);
+            // No channel conversion required, pass input directly
+            if (_needResampling)
+                _resampler->Process(input, inputFrames, output, outputFrames);
+            else
+                AudioBuffer::Copy(input, 0, output, 0, outputFrames);
+            return;
         }
 
-        AMPLITUDE_ASSERT(temp.GetChannelCount() == output.GetChannelCount());
+        // Reuse pre-allocated temp buffer for channel conversion
+        _tempBuffer.Clear();
+
+        if (_channelConversionMode == kChannelConversionModeMonoToStereo)
+            ConvertStereoFromMono(input, _tempBuffer);
+        else if (_channelConversionMode == kChannelConversionModeStereoToMono)
+            ConvertMonoFromStereo(input, _tempBuffer);
+
+        AMPLITUDE_ASSERT(_tempBuffer.GetChannelCount() == output.GetChannelCount());
 
         if (_needResampling)
-            _resampler->Process(temp, inputFrames, output, outputFrames);
+            _resampler->Process(_tempBuffer, inputFrames, output, outputFrames);
         else
-            AudioBuffer::Copy(temp, 0, output, 0, outputFrames);
+            AudioBuffer::Copy(_tempBuffer, 0, output, 0, outputFrames);
     }
 
     void AudioConverter::SetSampleRate(AmUInt64 sourceSampleRate, AmUInt64 targetSampleRate)
@@ -135,7 +142,7 @@ namespace SparkyStudios::Audio::Amplitude
     {
         AMPLITUDE_ASSERT(input.GetChannelCount() == 1);
         AMPLITUDE_ASSERT(output.GetChannelCount() == 2);
-        AMPLITUDE_ASSERT(input.GetFrameCount() == output.GetFrameCount());
+        AMPLITUDE_ASSERT(input.GetFrameCount() <= output.GetFrameCount());
 
         auto& left = output[0];
         auto& right = output[1];
@@ -149,10 +156,10 @@ namespace SparkyStudios::Audio::Amplitude
     {
         AMPLITUDE_ASSERT(input.GetChannelCount() == 2);
         AMPLITUDE_ASSERT(output.GetChannelCount() == 1);
-        AMPLITUDE_ASSERT(input.GetFrameCount() == output.GetFrameCount());
+        AMPLITUDE_ASSERT(input.GetFrameCount() <= output.GetFrameCount());
 
         const AmSize length = input.GetFrameCount();
-        AmSize remaining = input.GetFrameCount();
+        AmSize remaining = length;
         const AmReal32 invSqrt2 = InverseSquareRoot(2);
 
         const auto& left = input[0];

--- a/src/DSP/Gain.cpp
+++ b/src/DSP/Gain.cpp
@@ -58,10 +58,35 @@ namespace SparkyStudios::Audio::Amplitude
         AMPLITUDE_ASSERT(in.size() >= inOffset + frames);
         AMPLITUDE_ASSERT(out.size() >= outOffset + frames);
 
-        const AmReal32 step = 1.0f / frames;
+        const AmReal32 invFrames = 1.0f / static_cast<AmReal32>(frames);
+        const AmReal32 gainDelta = endGain - startGain;
 
-        for (AmSize j = 0; j < frames; ++j)
-            out[j + outOffset] = in[j + inOffset] * Lerp(step * j, startGain, endGain);
+        AmSize j = 0;
+
+#if defined(AM_SIMD_INTRINSICS)
+        constexpr AmSize blockSize = GetSimdBlockSize();
+        const AmSize simdEnd = (frames / blockSize) * blockSize;
+
+        if (simdEnd > 0)
+        {
+            alignas(AM_SIMD_ALIGNMENT) AmReal32 gainValues[blockSize];
+            for (AmSize i = 0; i < blockSize; ++i)
+                gainValues[i] = startGain + gainDelta * (invFrames * static_cast<AmReal32>(i));
+
+            auto gainVec = xsimd::load_aligned<simd_arch>(gainValues);
+            const auto stepVec = simd_batch(gainDelta * invFrames * static_cast<AmReal32>(blockSize));
+
+            for (; j < simdEnd; j += blockSize)
+            {
+                const auto inVec = xsimd::load_aligned<simd_arch>(&in[j + inOffset]);
+                xsimd::store_aligned<simd_arch>(&out[j + outOffset], inVec * gainVec);
+                gainVec += stepVec;
+            }
+        }
+#endif // AM_SIMD_INTRINSICS
+
+        for (; j < frames; ++j)
+            out[j + outOffset] = in[j + inOffset] * (startGain + gainDelta * (invFrames * static_cast<AmReal32>(j)));
     }
 
     void Gain::ApplyAccumulateLinearGain(
@@ -76,10 +101,36 @@ namespace SparkyStudios::Audio::Amplitude
         AMPLITUDE_ASSERT(in.size() >= inOffset + frames);
         AMPLITUDE_ASSERT(out.size() >= outOffset + frames);
 
-        const AmReal32 step = 1.0f / frames;
+        const AmReal32 invFrames = 1.0f / static_cast<AmReal32>(frames);
+        const AmReal32 gainDelta = endGain - startGain;
 
-        for (AmSize j = 0; j < frames; ++j)
-            out[j + outOffset] += in[j + inOffset] * Lerp(step * j, startGain, endGain);
+        AmSize j = 0;
+
+#if defined(AM_SIMD_INTRINSICS)
+        constexpr AmSize blockSize = GetSimdBlockSize();
+        const AmSize simdEnd = (frames / blockSize) * blockSize;
+
+        if (simdEnd > 0)
+        {
+            alignas(AM_SIMD_ALIGNMENT) AmReal32 gainValues[blockSize];
+            for (AmSize i = 0; i < blockSize; ++i)
+                gainValues[i] = startGain + gainDelta * (invFrames * static_cast<AmReal32>(i));
+
+            auto gainVec = xsimd::load_aligned<simd_arch>(gainValues);
+            const auto stepVec = simd_batch(gainDelta * invFrames * static_cast<AmReal32>(blockSize));
+
+            for (; j < simdEnd; j += blockSize)
+            {
+                const auto inVec = xsimd::load_aligned<simd_arch>(&in[j + inOffset]);
+                const auto outVec = xsimd::load_aligned<simd_arch>(&out[j + outOffset]);
+                xsimd::store_aligned<simd_arch>(&out[j + outOffset], xsimd::fma(inVec, gainVec, outVec));
+                gainVec += stepVec;
+            }
+        }
+#endif // AM_SIMD_INTRINSICS
+
+        for (; j < frames; ++j)
+            out[j + outOffset] += in[j + inOffset] * (startGain + gainDelta * (invFrames * static_cast<AmReal32>(j)));
     }
 
     void Gain::ApplyReplaceGain(
@@ -240,10 +291,50 @@ namespace SparkyStudios::Audio::Amplitude
         const AmReal32 step = (endGain - startGain) / static_cast<AmReal32>(rampLength);
 
         AmReal32 currentGain = startGain;
+        AmSize frame = 0;
 
+#if defined(AM_SIMD_INTRINSICS)
+        constexpr AmSize blockSize = GetSimdBlockSize();
+        const AmSize simdEnd = (length / blockSize) * blockSize;
+
+        if (simdEnd > 0)
+        {
+            // Build initial gain vector: {g, g+s, g+2s, g+3s, ...}
+            alignas(AM_SIMD_ALIGNMENT) AmReal32 gainValues[blockSize];
+            for (AmSize i = 0; i < blockSize; ++i)
+                gainValues[i] = currentGain + step * static_cast<AmReal32>(i);
+
+            auto gainVec = xsimd::load_aligned<simd_arch>(gainValues);
+            const auto stepVec = simd_batch(step * static_cast<AmReal32>(blockSize));
+
+            if (accumulate)
+            {
+                for (; frame < simdEnd; frame += blockSize)
+                {
+                    const auto inVec = xsimd::load_aligned<simd_arch>(in + frame);
+                    const auto outVec = xsimd::load_aligned<simd_arch>(out + frame);
+                    xsimd::store_aligned<simd_arch>(out + frame, xsimd::fma(inVec, gainVec, outVec));
+                    gainVec += stepVec;
+                }
+            }
+            else
+            {
+                for (; frame < simdEnd; frame += blockSize)
+                {
+                    const auto inVec = xsimd::load_aligned<simd_arch>(in + frame);
+                    xsimd::store_aligned<simd_arch>(out + frame, inVec * gainVec);
+                    gainVec += stepVec;
+                }
+            }
+
+            currentGain = startGain + step * static_cast<AmReal32>(simdEnd);
+        }
+#endif // AM_SIMD_INTRINSICS
+
+        // Scalar tail
         if (accumulate)
         {
-            for (AmSize frame = 0; frame < length; ++frame)
+            for (; frame < length; ++frame)
             {
                 out[frame] += currentGain * in[frame];
                 currentGain += step;
@@ -251,7 +342,7 @@ namespace SparkyStudios::Audio::Amplitude
         }
         else
         {
-            for (AmSize frame = 0; frame < length; ++frame)
+            for (; frame < length; ++frame)
             {
                 out[frame] = currentGain * in[frame];
                 currentGain += step;

--- a/src/IO/MappedFile.cpp
+++ b/src/IO/MappedFile.cpp
@@ -166,6 +166,9 @@ namespace SparkyStudios::Audio::Amplitude
         if (bytes > m_dataSize - m_offset)
             bytes = m_dataSize - m_offset;
 
+        if (bytes == 0)
+            return 0;
+
         std::memcpy(dst, m_dataPtr + m_offset, bytes);
         m_offset += bytes;
 

--- a/src/IO/MappedFile.cpp
+++ b/src/IO/MappedFile.cpp
@@ -1,0 +1,304 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Core/Memory.h>
+
+#include <SparkyStudios/Audio/Amplitude/IO/DiskFile.h>
+#include <SparkyStudios/Audio/Amplitude/IO/MappedFile.h>
+
+#if AM_PLATFORM_WIN
+// Windows.h already included via Config.h
+#elif AM_PLATFORM_LINUX || AM_PLATFORM_APPLE
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace SparkyStudios::Audio::Amplitude
+{
+    namespace
+    {
+        constexpr AmSize kMmapThreshold = 1024 * 1024; // 1 MB
+
+        struct MappingResult
+        {
+            AmUInt8Buffer data;
+            AmSize size;
+            AmVoidPtr handle;
+            bool success;
+        };
+
+        MappingResult CreateMapping(const std::filesystem::path& path, AmSize fileSize)
+        {
+            MappingResult result{};
+            result.data = nullptr;
+            result.size = fileSize;
+            result.handle = nullptr;
+            result.success = false;
+
+#if AM_PLATFORM_WIN
+            HANDLE fileHandle =
+                CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+
+            if (fileHandle == INVALID_HANDLE_VALUE)
+                return result;
+
+            HANDLE mappingHandle = CreateFileMappingW(fileHandle, nullptr, PAGE_READONLY, 0, 0, nullptr);
+            if (mappingHandle == nullptr)
+            {
+                CloseHandle(fileHandle);
+                return result;
+            }
+
+            result.data = static_cast<AmUInt8Buffer>(MapViewOfFile(mappingHandle, FILE_MAP_READ, 0, 0, 0));
+            if (result.data == nullptr)
+            {
+                CloseHandle(mappingHandle);
+                CloseHandle(fileHandle);
+                return result;
+            }
+
+            // Store both handles so Close() can release them
+            auto* handles = static_cast<HANDLE*>(ampoolmalloc(eMemoryPoolKind_IO, sizeof(HANDLE) * 2));
+            handles[0] = fileHandle;
+            handles[1] = mappingHandle;
+            result.handle = handles;
+            result.success = true;
+
+#elif AM_PLATFORM_LINUX || AM_PLATFORM_APPLE
+            int fd = open(path.c_str(), O_RDONLY);
+            if (fd == -1)
+                return result;
+
+            result.data = static_cast<AmUInt8Buffer>(mmap(nullptr, fileSize, PROT_READ, MAP_PRIVATE, fd, 0));
+
+            // File descriptor can be closed immediately after mmap; the mapping holds its own reference.
+            close(fd);
+
+            if (result.data == MAP_FAILED)
+            {
+                result.data = nullptr;
+                return result;
+            }
+
+            result.success = true;
+#else
+            AM_UNUSED(path);
+            AM_UNUSED(fileSize);
+#endif
+
+            return result;
+        }
+
+        void DestroyMapping(AmUInt8Buffer data, AmSize size, AmVoidPtr handle)
+        {
+            if (data == nullptr)
+                return;
+
+#if AM_PLATFORM_WIN
+            UnmapViewOfFile(data);
+
+            if (handle != nullptr)
+            {
+                auto* handles = static_cast<HANDLE*>(handle);
+                CloseHandle(handles[1]); // mapping handle
+                CloseHandle(handles[0]); // file handle
+                ampoolfree(eMemoryPoolKind_IO, handles);
+            }
+#elif AM_PLATFORM_LINUX || AM_PLATFORM_APPLE
+            munmap(data, size);
+            AM_UNUSED(handle);
+#else
+            AM_UNUSED(data);
+            AM_UNUSED(size);
+            AM_UNUSED(handle);
+#endif
+        }
+    } // anonymous namespace
+
+    MappedFile::MappedFile()
+        : m_dataPtr(nullptr)
+        , m_dataSize(0)
+        , m_offset(0)
+        , m_isMapped(false)
+        , m_dataOwned(false)
+        , m_mapHandle(nullptr)
+    {}
+
+    MappedFile::MappedFile(const std::filesystem::path& fileName)
+        : MappedFile()
+    {
+        Open(fileName);
+    }
+
+    MappedFile::~MappedFile()
+    {
+        Close();
+    }
+
+    AmOsString MappedFile::GetPath() const
+    {
+        return m_filePath.c_str();
+    }
+
+    bool MappedFile::Eof() const
+    {
+        return m_offset >= m_dataSize;
+    }
+
+    AmSize MappedFile::Read(AmUInt8Buffer dst, AmSize bytes) const
+    {
+        if (m_dataPtr == nullptr)
+            return 0;
+
+        if (m_offset + bytes >= m_dataSize)
+            bytes = m_dataSize - m_offset;
+
+        std::memcpy(dst, m_dataPtr + m_offset, bytes);
+        m_offset += bytes;
+
+        return bytes;
+    }
+
+    AmSize MappedFile::Write(AmConstUInt8Buffer src, AmSize bytes)
+    {
+        AM_UNUSED(src);
+        AM_UNUSED(bytes);
+        return 0;
+    }
+
+    AmSize MappedFile::Length() const
+    {
+        return m_dataSize;
+    }
+
+    void MappedFile::Seek(AmInt64 offset, eFileSeekOrigin origin)
+    {
+        if (origin == eFileSeekOrigin_Start)
+            m_offset = offset;
+        else if (origin == eFileSeekOrigin_Current)
+            m_offset += offset;
+        else if (origin == eFileSeekOrigin_End)
+            m_offset = m_dataSize + offset;
+
+        if (m_dataSize > 0 && m_offset > m_dataSize - 1)
+            m_offset = m_dataSize - 1;
+    }
+
+    AmSize MappedFile::Position() const
+    {
+        return m_offset;
+    }
+
+    AmVoidPtr MappedFile::GetPtr() const
+    {
+        return m_dataPtr;
+    }
+
+    bool MappedFile::IsValid() const
+    {
+        return m_dataPtr != nullptr;
+    }
+
+    void MappedFile::Close()
+    {
+        if (m_dataPtr == nullptr)
+            return;
+
+        if (m_isMapped)
+            DestroyMapping(m_dataPtr, m_dataSize, m_mapHandle);
+        else if (m_dataOwned)
+            ampoolfree(eMemoryPoolKind_IO, m_dataPtr);
+
+        m_dataPtr = nullptr;
+        m_dataSize = 0;
+        m_offset = 0;
+        m_isMapped = false;
+        m_dataOwned = false;
+        m_mapHandle = nullptr;
+        m_filePath.clear();
+    }
+
+    AmResult MappedFile::Open(const std::filesystem::path& filePath)
+    {
+        if (filePath.empty())
+            return eErrorCode_InvalidParameter;
+
+        Close();
+
+        // Open file to determine size
+        DiskFile df;
+        if (const AmResult res = df.Open(filePath); res != eErrorCode_Success)
+            return res;
+
+        const AmSize fileSize = df.Length();
+
+        m_filePath = filePath;
+        m_dataSize = fileSize;
+
+        // Empty files need no mapping or allocation
+        if (fileSize == 0)
+        {
+            df.Close();
+            m_dataPtr = nullptr;
+            m_isMapped = false;
+            m_dataOwned = false;
+            return eErrorCode_Success;
+        }
+
+        // Try memory mapping for files >= threshold
+        if (fileSize >= kMmapThreshold)
+        {
+            df.Close();
+
+            MappingResult mapping = CreateMapping(filePath, fileSize);
+            if (mapping.success)
+            {
+                m_dataPtr = mapping.data;
+                m_dataSize = mapping.size;
+                m_mapHandle = mapping.handle;
+                m_isMapped = true;
+                m_dataOwned = false;
+                return eErrorCode_Success;
+            }
+
+            // Mapping failed; reopen for heap fallback
+            if (const AmResult res = df.Open(filePath); res != eErrorCode_Success)
+                return res;
+        }
+
+        // Heap fallback
+        m_dataPtr = static_cast<AmUInt8Buffer>(ampoolmalloc(eMemoryPoolKind_IO, m_dataSize));
+        if (m_dataPtr == nullptr)
+        {
+            df.Close();
+            return eErrorCode_OutOfMemory;
+        }
+
+        df.Seek(0, eFileSeekOrigin_Start);
+        df.Read(m_dataPtr, m_dataSize);
+        df.Close();
+
+        m_isMapped = false;
+        m_dataOwned = true;
+
+        return eErrorCode_Success;
+    }
+
+    bool MappedFile::IsMapped() const
+    {
+        return m_isMapped;
+    }
+} // namespace SparkyStudios::Audio::Amplitude

--- a/src/IO/MappedFile.cpp
+++ b/src/IO/MappedFile.cpp
@@ -160,10 +160,10 @@ namespace SparkyStudios::Audio::Amplitude
 
     AmSize MappedFile::Read(AmUInt8Buffer dst, AmSize bytes) const
     {
-        if (m_dataPtr == nullptr)
+        if (m_dataPtr == nullptr || m_offset >= m_dataSize)
             return 0;
 
-        if (m_offset + bytes >= m_dataSize)
+        if (bytes > m_dataSize - m_offset)
             bytes = m_dataSize - m_offset;
 
         std::memcpy(dst, m_dataPtr + m_offset, bytes);
@@ -186,15 +186,16 @@ namespace SparkyStudios::Audio::Amplitude
 
     void MappedFile::Seek(AmInt64 offset, eFileSeekOrigin origin)
     {
-        if (origin == eFileSeekOrigin_Start)
-            m_offset = offset;
-        else if (origin == eFileSeekOrigin_Current)
-            m_offset += offset;
-        else if (origin == eFileSeekOrigin_End)
-            m_offset = m_dataSize + offset;
+        AmInt64 newOffset = 0;
 
-        if (m_dataSize > 0 && m_offset > m_dataSize - 1)
-            m_offset = m_dataSize - 1;
+        if (origin == eFileSeekOrigin_Start)
+            newOffset = offset;
+        else if (origin == eFileSeekOrigin_Current)
+            newOffset = static_cast<AmInt64>(m_offset) + offset;
+        else if (origin == eFileSeekOrigin_End)
+            newOffset = static_cast<AmInt64>(m_dataSize) + offset;
+
+        m_offset = AM_CLAMP(newOffset, 0, static_cast<AmInt64>(m_dataSize));
     }
 
     AmSize MappedFile::Position() const

--- a/src/IO/MemoryFile.cpp
+++ b/src/IO/MemoryFile.cpp
@@ -55,6 +55,9 @@ namespace SparkyStudios::Audio::Amplitude
         if (bytes > m_dataSize - m_offset)
             bytes = m_dataSize - m_offset;
 
+        if (bytes == 0)
+            return 0;
+
         std::memcpy(dst, m_dataPtr + m_offset, bytes);
         m_offset += bytes;
 

--- a/src/IO/MemoryFile.cpp
+++ b/src/IO/MemoryFile.cpp
@@ -49,7 +49,10 @@ namespace SparkyStudios::Audio::Amplitude
 
     AmSize MemoryFile::Read(AmUInt8Buffer dst, AmSize bytes) const
     {
-        if (m_offset + bytes >= m_dataSize)
+        if (m_dataPtr == nullptr || m_offset >= m_dataSize)
+            return 0;
+
+        if (bytes > m_dataSize - m_offset)
             bytes = m_dataSize - m_offset;
 
         std::memcpy(dst, m_dataPtr + m_offset, bytes);
@@ -60,6 +63,9 @@ namespace SparkyStudios::Audio::Amplitude
 
     AmSize MemoryFile::Write(AmConstUInt8Buffer src, AmSize bytes)
     {
+        if (m_dataPtr == nullptr || m_offset >= m_dataSize)
+            return 0;
+
         const auto bytesToWrite = std::min(bytes, m_dataSize - m_offset);
 
         std::memcpy(m_dataPtr + m_offset, src, bytesToWrite);
@@ -75,15 +81,16 @@ namespace SparkyStudios::Audio::Amplitude
 
     void MemoryFile::Seek(AmInt64 offset, eFileSeekOrigin origin)
     {
-        if (origin == eFileSeekOrigin_Start)
-            m_offset = offset;
-        else if (origin == eFileSeekOrigin_Current)
-            m_offset += offset;
-        else if (origin == eFileSeekOrigin_End)
-            m_offset = m_dataSize + offset;
+        AmInt64 newOffset = 0;
 
-        if (m_offset > m_dataSize - 1)
-            m_offset = m_dataSize - 1;
+        if (origin == eFileSeekOrigin_Start)
+            newOffset = offset;
+        else if (origin == eFileSeekOrigin_Current)
+            newOffset = static_cast<AmInt64>(m_offset) + offset;
+        else if (origin == eFileSeekOrigin_End)
+            newOffset = static_cast<AmInt64>(m_dataSize) + offset;
+
+        m_offset = AM_CLAMP(newOffset, 0, static_cast<AmInt64>(m_dataSize));
     }
 
     AmSize MemoryFile::Position() const

--- a/src/IO/PackageItemFile.cpp
+++ b/src/IO/PackageItemFile.cpp
@@ -15,6 +15,8 @@
 #include <SparkyStudios/Audio/Amplitude/Core/Memory.h>
 #include <SparkyStudios/Audio/Amplitude/IO/PackageItemFile.h>
 
+#include <limits>
+
 #include <lz4.h>
 
 namespace SparkyStudios::Audio::Amplitude
@@ -24,12 +26,23 @@ namespace SparkyStudios::Audio::Amplitude
         , _isCompressed(item->m_CompressedBlockSize > 0)
         , _headerSize(headerSize)
         , _packageFile(packageFile)
+        , _compressedBuffer(nullptr)
+        , _compressedBufferCapacity(0)
+        , _decompressedBuffer(nullptr)
+        , _decompressedBufferCapacity(0)
+        , _cachedChunkIndex(std::numeric_limits<AmSize>::max())
     {
         Seek(0, eFileSeekOrigin_Start);
     }
 
     PackageItemFile::~PackageItemFile()
     {
+        if (_compressedBuffer != nullptr)
+            ampoolfree(eMemoryPoolKind_IO, _compressedBuffer);
+
+        if (_decompressedBuffer != nullptr)
+            ampoolfree(eMemoryPoolKind_IO, _decompressedBuffer);
+
         _packageFile.reset();
     }
 
@@ -53,33 +66,56 @@ namespace SparkyStudios::Audio::Amplitude
 
         if (_isCompressed)
         {
-            AmSize readSize = 0;
-
             const AmSize firstChunk = _currentPosition / _description->m_CompressedBlockSize;
             const AmSize lastChunk = (_currentPosition + bytes - 1) / _description->m_CompressedBlockSize;
 
+            AmUInt8* dstPtr = dst;
             AmSize remaining = bytes;
+
             for (AmSize ci = firstChunk; ci <= lastChunk; ++ci)
             {
                 const auto& ch = _description->m_CompressedChunks[ci];
-                std::vector<AmUInt8> compressed(ch.m_CompressedSize);
 
-                _packageFile->Seek(GetBasePosition() + ch.m_Offset, eFileSeekOrigin_Start);
-                _packageFile->Read(compressed.data(), ch.m_CompressedSize);
+                if (ch.m_CompressedSize > _compressedBufferCapacity)
+                {
+                    _compressedBuffer = static_cast<AmUInt8*>(
+                        ampoolrealloc(eMemoryPoolKind_IO, _compressedBuffer, ch.m_CompressedSize));
+                    _compressedBufferCapacity = ch.m_CompressedSize;
+                }
 
-                std::vector<char> decompressed(ch.m_Size);
-                LZ4_decompress_safe(reinterpret_cast<char*>(compressed.data()), decompressed.data(), ch.m_CompressedSize, ch.m_Size);
+                if (ch.m_Size > _decompressedBufferCapacity)
+                {
+                    _decompressedBuffer = static_cast<AmUInt8*>(
+                        ampoolrealloc(eMemoryPoolKind_IO, _decompressedBuffer, ch.m_Size));
+                    _decompressedBufferCapacity = ch.m_Size;
+                    _cachedChunkIndex = std::numeric_limits<AmSize>::max();
+                }
 
-                AmSize chunkStartOffset = (ci == firstChunk) ? _currentPosition % _description->m_CompressedBlockSize : 0;
-                AmSize copyLen = std::min(ch.m_Size - chunkStartOffset, remaining);
+                if (_cachedChunkIndex != ci)
+                {
+                    _packageFile->Seek(GetBasePosition() + ch.m_Offset, eFileSeekOrigin_Start);
+                    _packageFile->Read(_compressedBuffer, ch.m_CompressedSize);
 
-                std::memcpy(dst, decompressed.data() + chunkStartOffset, copyLen);
+                    LZ4_decompress_safe(
+                        reinterpret_cast<char*>(_compressedBuffer),
+                        reinterpret_cast<char*>(_decompressedBuffer),
+                        ch.m_CompressedSize,
+                        ch.m_Size);
 
+                    _cachedChunkIndex = ci;
+                }
+
+                const AmSize chunkStartOffset = (ci == firstChunk) ? _currentPosition % _description->m_CompressedBlockSize : 0;
+                const AmSize copyLen = AM_MIN(ch.m_Size - chunkStartOffset, remaining);
+
+                std::memcpy(dstPtr, _decompressedBuffer + chunkStartOffset, copyLen);
+
+                dstPtr += copyLen;
                 remaining -= copyLen;
             }
 
             _currentPosition += bytes - remaining;
-            return bytes;
+            return bytes - remaining;
         }
 
         _packageFile->Seek(GetBasePosition() + _currentPosition, eFileSeekOrigin_Start);
@@ -154,6 +190,22 @@ namespace SparkyStudios::Audio::Amplitude
     {
         if (_packageFile == nullptr)
             return;
+
+        if (_compressedBuffer != nullptr)
+        {
+            ampoolfree(eMemoryPoolKind_IO, _compressedBuffer);
+            _compressedBuffer = nullptr;
+            _compressedBufferCapacity = 0;
+        }
+
+        if (_decompressedBuffer != nullptr)
+        {
+            ampoolfree(eMemoryPoolKind_IO, _decompressedBuffer);
+            _decompressedBuffer = nullptr;
+            _decompressedBufferCapacity = 0;
+        }
+
+        _cachedChunkIndex = std::numeric_limits<AmSize>::max();
 
         _packageFile->Close();
         _packageFile.reset();

--- a/src/IO/PackageItemFile.cpp
+++ b/src/IO/PackageItemFile.cpp
@@ -78,15 +78,13 @@ namespace SparkyStudios::Audio::Amplitude
 
                 if (ch.m_CompressedSize > _compressedBufferCapacity)
                 {
-                    _compressedBuffer = static_cast<AmUInt8*>(
-                        ampoolrealloc(eMemoryPoolKind_IO, _compressedBuffer, ch.m_CompressedSize));
+                    _compressedBuffer = static_cast<AmUInt8*>(ampoolrealloc(eMemoryPoolKind_IO, _compressedBuffer, ch.m_CompressedSize));
                     _compressedBufferCapacity = ch.m_CompressedSize;
                 }
 
                 if (ch.m_Size > _decompressedBufferCapacity)
                 {
-                    _decompressedBuffer = static_cast<AmUInt8*>(
-                        ampoolrealloc(eMemoryPoolKind_IO, _decompressedBuffer, ch.m_Size));
+                    _decompressedBuffer = static_cast<AmUInt8*>(ampoolrealloc(eMemoryPoolKind_IO, _decompressedBuffer, ch.m_Size));
                     _decompressedBufferCapacity = ch.m_Size;
                     _cachedChunkIndex = std::numeric_limits<AmSize>::max();
                 }
@@ -96,11 +94,13 @@ namespace SparkyStudios::Audio::Amplitude
                     _packageFile->Seek(GetBasePosition() + ch.m_Offset, eFileSeekOrigin_Start);
                     _packageFile->Read(_compressedBuffer, ch.m_CompressedSize);
 
-                    LZ4_decompress_safe(
-                        reinterpret_cast<char*>(_compressedBuffer),
-                        reinterpret_cast<char*>(_decompressedBuffer),
-                        ch.m_CompressedSize,
-                        ch.m_Size);
+                    const int decompressedSize = LZ4_decompress_safe(
+                        reinterpret_cast<char*>(_compressedBuffer), reinterpret_cast<char*>(_decompressedBuffer),
+                        static_cast<int>(ch.m_CompressedSize), static_cast<int>(ch.m_Size));
+
+                    // Decompression failed; return the number of bytes successfully read so far.
+                    if (decompressedSize < 0)
+                        return bytes - remaining;
 
                     _cachedChunkIndex = ci;
                 }

--- a/src/Mixer/Amplimix.cpp
+++ b/src/Mixer/Amplimix.cpp
@@ -19,11 +19,14 @@
 #include <Mixer/Amplimix.h>
 #include <Mixer/Pipeline.h>
 
-#include <thread>
-
 #define AMPLIMIX_STORE(A, C) std::atomic_store_explicit(A, (C), std::memory_order_release)
 #define AMPLIMIX_LOAD(A) std::atomic_load_explicit(A, std::memory_order_acquire)
 #define AMPLIMIX_CSWAP(A, E, C) std::atomic_compare_exchange_strong_explicit(A, E, C, std::memory_order_acq_rel, std::memory_order_acquire)
+
+// Relaxed load/store for independently meaningful values (gain, cursor, etc.)
+// where no ordering with other memory operations is required.
+#define AMPLIMIX_LOAD_RELAXED(A) std::atomic_load_explicit(A, std::memory_order_relaxed)
+#define AMPLIMIX_STORE_RELAXED(A, C) std::atomic_store_explicit(A, (C), std::memory_order_relaxed)
 
 namespace SparkyStudios::Audio::Amplitude
 {
@@ -68,64 +71,12 @@ namespace SparkyStudios::Audio::Amplitude
         bool m_locked = false;
     };
 
-    struct AmplimixLayerMutexLocker
-    {
-        explicit AmplimixLayerMutexLocker(AmplimixLayerImpl* layer)
-            : m_layer(layer)
-            , _haveLocked(false)
-        {
-            Lock();
-        }
-
-        ~AmplimixLayerMutexLocker()
-        {
-            Unlock();
-        }
-
-    public:
-        void Lock()
-        {
-            if (_haveLocked)
-                return; // Avoid double locking in same instance
-
-            m_layer->mutex.lock();
-
-            MarkLayerAsLocked();
-        }
-
-        void Unlock()
-        {
-            if (!_haveLocked)
-                return;
-
-            m_layer->mutex.unlock();
-
-            MarkLayerAsUnlocked();
-        }
-
-    private:
-        void MarkLayerAsLocked()
-        {
-            _haveLocked = true;
-        }
-
-        void MarkLayerAsUnlocked()
-        {
-            _haveLocked = false;
-        }
-
-        AmplimixLayerImpl* m_layer;
-        bool _haveLocked;
-    };
-
     constexpr AmUInt32 kProcessedFramesCount = GetSimdBlockSize();
 
     static void OnSoundDestroyed(AmplimixImpl* mixer, AmplimixLayerImpl* layer);
 
     static bool ShouldLoopSound(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         const auto* sound = layer->snd->sound.get();
         const AmUInt32 loopCount = sound->GetSettings().m_loopCount;
 
@@ -134,8 +85,6 @@ namespace SparkyStudios::Audio::Amplitude
 
     static void OnSoundStarted(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         const auto* sound = layer->snd->sound.get();
         amLogDebug("Started sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetPath().c_str());
 
@@ -147,8 +96,6 @@ namespace SparkyStudios::Audio::Amplitude
 
     static void OnSoundPaused(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         const auto* sound = layer->snd->sound.get();
         amLogDebug("Paused sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetPath().c_str());
 
@@ -160,8 +107,6 @@ namespace SparkyStudios::Audio::Amplitude
 
     static void OnSoundResumed(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         const auto* sound = layer->snd->sound.get();
         amLogDebug("Resumed sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetPath().c_str());
 
@@ -173,8 +118,6 @@ namespace SparkyStudios::Audio::Amplitude
 
     static void OnSoundStopped(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         const auto* sound = layer->snd->sound.get();
         amLogDebug("Stopped sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetPath().c_str());
 
@@ -186,8 +129,6 @@ namespace SparkyStudios::Audio::Amplitude
 
     static bool OnSoundLooped(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         auto* sound = layer->snd->sound.get();
         amLogDebug("Looped sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetPath().c_str());
 
@@ -208,8 +149,6 @@ namespace SparkyStudios::Audio::Amplitude
 
     static AmUInt64 OnSoundStream(AmplimixImpl* mixer, AmplimixLayerImpl* layer, AmUInt64 offset, AmUInt64 frames)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         if (!layer->snd->stream)
             return 0;
 
@@ -219,8 +158,6 @@ namespace SparkyStudios::Audio::Amplitude
 
     static void OnSoundEnded(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         auto* sound = layer->snd->sound.get();
         amLogDebug("Ended sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetPath().c_str());
 
@@ -299,19 +236,11 @@ namespace SparkyStudios::Audio::Amplitude
 
     static void OnSoundDestroyed(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         if (layer->snd == nullptr)
             return;
 
-        // Clean up the pipeline
-        layer->pipeline = nullptr;
-
-        // Clean up the sound instance
-        layer->snd->sound.reset();
-        layer->snd = nullptr;
-
-        AMPLIMIX_STORE(&layer->flag, ePSF_MIN);
+        mixer->DeactivateLayer(mixer->GetLayerIndex(layer));
+        layer->Destroy();
     }
 
     static void MixMono(AmUInt64 index, const simd_batch& gain, const AudioBufferChannel& in, AudioBufferChannel& out)
@@ -330,7 +259,6 @@ namespace SparkyStudios::Audio::Amplitude
         : _initialized(false)
         , _commandsStack()
         , _audioThreadMutex()
-        , _insideAudioThreadMutex()
         , _nextId(0)
         , _masterGain()
         , _layers()
@@ -369,6 +297,10 @@ namespace SparkyStudios::Audio::Amplitude
         _device.mRequestedOutputChannels = PlaybackOutputChannels::Stereo; // For now, only support stereo output.
         _device.mRequestedOutputFormat = static_cast<PlaybackOutputFormat>(config->output()->format());
 
+        // Publish to atomic snapshots for audio-thread reads
+        AMPLIMIX_STORE_RELAXED(&_mixOutputSampleRate, _device.mRequestedOutputSampleRate);
+        AMPLIMIX_STORE_RELAXED(&_mixOutputChannels, _device.mRequestedOutputChannels);
+
         _initialized = true;
 
         return true;
@@ -381,12 +313,13 @@ namespace SparkyStudios::Audio::Amplitude
 
         AMPLITUDE_ASSERT(!IsInsideThreadMutex());
 
-        _initialized = false;
+        // Drain any pending deferred commands
+        ExecuteCommands();
 
+        _initialized = false;
         _pipeline = nullptr;
 
-        for (auto& layer : _layers)
-            layer.Reset();
+        _activeLayerCount = 0;
     }
 
     void AmplimixImpl::UpdateDevice(
@@ -401,6 +334,10 @@ namespace SparkyStudios::Audio::Amplitude
         _device.mDeviceOutputSampleRate = deviceOutputSampleRate;
         _device.mDeviceOutputChannels = deviceOutputChannels;
         _device.mDeviceOutputFormat = deviceOutputFormat;
+
+        // Publish to atomic snapshots for audio-thread reads
+        AMPLIMIX_STORE_RELAXED(&_mixOutputSampleRate, _device.mRequestedOutputSampleRate);
+        AMPLIMIX_STORE_RELAXED(&_mixOutputChannels, _device.mRequestedOutputChannels);
     }
 
     void AmplimixImpl::SetAfterMixCallback(AfterMixCallback callback)
@@ -446,10 +383,12 @@ namespace SparkyStudios::Audio::Amplitude
 
         // begin actual mixing
         bool hasMixedAtLeastOneLayer = false;
-        for (auto&& layer : _layers)
+        for (AmUInt32 i = 0; i < _activeLayerCount; ++i)
         {
             if (amEngine->IsStopping())
                 break; // Stop mixing if engine is stopping
+
+            auto& layer = _layers[_activeLayerIndices[i]];
 
             if (!ShouldMix(&layer))
                 continue;
@@ -556,8 +495,8 @@ namespace SparkyStudios::Audio::Amplitude
             // atomically set cursor to start position based on given argument
             AMPLIMIX_STORE(&lay->cursor, lay->start);
 
-            const AmReal32 baseRatio =
-                static_cast<AmReal32>(sound->format.GetSampleRate()) / static_cast<AmReal32>(_device.mRequestedOutputSampleRate);
+            const AmUInt32 reqSampleRate = AMPLIMIX_LOAD_RELAXED(&_mixOutputSampleRate);
+            const AmReal32 baseRatio = static_cast<AmReal32>(sound->format.GetSampleRate()) / static_cast<AmReal32>(reqSampleRate);
             // store the base sample rate ratio for this source
             AMPLIMIX_STORE(&lay->baseSampleRateRatio, baseRatio);
             // store the initial value for sample rate ratio
@@ -567,9 +506,7 @@ namespace SparkyStudios::Audio::Amplitude
             lay->dataConverter = ampoolnew(eMemoryPoolKind_Amplimix, AudioConverter);
 
             const auto soundChannels = static_cast<AmUInt32>(sound->format.GetNumChannels());
-
             const AmUInt32 soundSampleRate = sound->format.GetSampleRate();
-            const AmUInt32 reqSampleRate = _device.mRequestedOutputSampleRate;
 
             AudioConverter::Settings converterSettings{};
             converterSettings.m_sourceChannelCount = soundChannels;
@@ -585,6 +522,10 @@ namespace SparkyStudios::Audio::Amplitude
 
             // store flag last, releasing the layer to the mixer thread
             AMPLIMIX_STORE(&lay->flag, flag);
+
+            // Add to active layer list
+            ActivateLayer(GetLayerIndex(lay));
+
             OnSoundStarted(this, lay);
         }
 
@@ -594,100 +535,67 @@ namespace SparkyStudios::Audio::Amplitude
     bool AmplimixImpl::SetObstruction(AmUInt32 id, AmUInt32 layer, AmReal32 obstruction)
     {
         auto* lay = GetLayer(layer);
-        AmplimixLayerMutexLocker lock(lay);
 
-        // check id and state flag to make sure the id is valid
-        if (id != lay->id || AMPLIMIX_LOAD(&lay->flag) <= ePSF_STOP)
-        {
-            // return failure
+        if (AMPLIMIX_LOAD(&lay->flag) <= ePSF_STOP || id != lay->id)
             return false;
-        }
 
-        // store the obstruction factor in the layer
         AMPLIMIX_STORE(&lay->obstruction, obstruction);
 
-        // return success
         return true;
     }
 
     bool AmplimixImpl::SetOcclusion(AmUInt32 id, AmUInt32 layer, AmReal32 occlusion)
     {
         auto* lay = GetLayer(layer);
-        AmplimixLayerMutexLocker lock(lay);
 
-        // check id and state flag to make sure the id is valid
-        if (id != lay->id || AMPLIMIX_LOAD(&lay->flag) <= ePSF_STOP)
-        {
-            // return failure
+        if (AMPLIMIX_LOAD(&lay->flag) <= ePSF_STOP || id != lay->id)
             return false;
-        }
 
-        // store the occlusion factor in the layer
         AMPLIMIX_STORE(&lay->occlusion, occlusion);
 
-        // return success
         return true;
     }
 
     bool AmplimixImpl::SetGain(AmUInt32 id, AmUInt32 layer, AmReal32 gain)
     {
         auto* lay = GetLayer(layer);
-        AmplimixLayerMutexLocker lock(lay);
 
-        // check id and state flag to make sure the id is valid
-        if (id != lay->id || AMPLIMIX_LOAD(&lay->flag) <= ePSF_STOP)
-        {
-            // return failure
+        if (AMPLIMIX_LOAD(&lay->flag) <= ePSF_STOP || id != lay->id)
             return false;
-        }
 
-        // store the gain
         AMPLIMIX_STORE(&lay->gain, gain);
 
-        // return success
         return true;
     }
 
     bool AmplimixImpl::SetPitch(AmUInt32 id, AmUInt32 layer, AmReal32 pitch)
     {
         auto* lay = GetLayer(layer);
-        AmplimixLayerMutexLocker lock(lay);
 
-        // check id and state flag to make sure the id is valid
-        if ((id == lay->id) && (AMPLIMIX_LOAD(&lay->flag) > ePSF_STOP))
-        {
-            // store the pitch value atomically
-            AMPLIMIX_STORE(&lay->pitch, pitch);
-            // return success
-            return true;
-        }
+        if (AMPLIMIX_LOAD(&lay->flag) <= ePSF_STOP || id != lay->id)
+            return false;
 
-        // return failure
-        return false;
+        AMPLIMIX_STORE(&lay->pitch, pitch);
+
+        return true;
     }
 
     bool AmplimixImpl::SetCursor(AmUInt32 id, AmUInt32 layer, AmUInt64 cursor)
     {
         auto* lay = GetLayer(layer);
-        AmplimixLayerMutexLocker lock(lay);
 
-        // check id and state flag to make sure the id is valid
-        if ((id == lay->id) && (AMPLIMIX_LOAD(&lay->flag) > ePSF_STOP))
-        {
+        if (AMPLIMIX_LOAD(&lay->flag) <= ePSF_STOP || id != lay->id)
+            return false;
+
 #if defined(AM_SIMD_INTRINSICS)
-            // clamp cursor and truncate to multiple of 16 before storing
-            AMPLIMIX_STORE(&lay->cursor, AM_CLAMP(cursor, lay->start, lay->end) & ~(kProcessedFramesCount - 1));
+        // clamp cursor and truncate to multiple of kProcessedFramesCount before storing
+        AMPLIMIX_STORE(&lay->cursor, AM_CLAMP(cursor, lay->start, lay->end) & ~(kProcessedFramesCount - 1));
 #else
-            // clamp cursor and store it
-            AMPLIMIX_STORE(&lay->cursor, AM_CLAMP(cursor, lay->start, lay->end));
+        // clamp cursor and store it
+        AMPLIMIX_STORE(&lay->cursor, AM_CLAMP(cursor, lay->start, lay->end));
 #endif // AM_SIMD_INTRINSICS
 
-            // return success
-            return true;
-        }
-
-        // return failure
-        return false;
+        return true;
     }
 
     bool AmplimixImpl::SetPlayState(AmUInt32 id, AmUInt32 layer, PlayStateFlag flag)
@@ -723,8 +631,14 @@ namespace SparkyStudios::Audio::Amplitude
             {
                 if (flag == ePSF_STOP)
                 {
-                    // Destroy the sound instance on stop
-                    OnSoundDestroyed(this, lay);
+                    // Defer sound destruction to the audio thread via command queue.
+                    // The CAS to ePSF_STOP prevents ShouldMix() from returning true,
+                    // so the audio thread will not access this layer during the next mix cycle.
+                    PushCommand({ [this, lay]() -> bool
+                                  {
+                                      OnSoundDestroyed(this, lay);
+                                      return true;
+                                  } });
                 }
 
                 return true;
@@ -739,7 +653,6 @@ namespace SparkyStudios::Audio::Amplitude
     {
         // get layer based on the lowest bits of id
         auto* lay = GetLayer(layer);
-        AmplimixLayerMutexLocker lock(lay);
 
         // check id and state flag to make sure the id is valid
         if (PlayStateFlag flag; (id == lay->id) && ((flag = AMPLIMIX_LOAD(&lay->flag)) > ePSF_STOP))
@@ -755,23 +668,18 @@ namespace SparkyStudios::Audio::Amplitude
     bool AmplimixImpl::SetPlaySpeed(AmUInt32 id, AmUInt32 layer, AmReal32 speed)
     {
         auto* lay = GetLayer(layer);
-        AmplimixLayerMutexLocker lock(lay);
 
-        // check id and state flag to make sure the id is valid
-        if ((id == lay->id) && (AMPLIMIX_LOAD(&lay->flag) > ePSF_STOP))
-        {
-            AMPLIMIX_STORE(&lay->userPlaySpeed, speed);
-            // return success
-            return true;
-        }
+        if (AMPLIMIX_LOAD(&lay->flag) <= ePSF_STOP || id != lay->id)
+            return false;
 
-        // return failure
-        return false;
+        AMPLIMIX_STORE(&lay->userPlaySpeed, speed);
+
+        return true;
     }
 
     void AmplimixImpl::SetMasterGain(AmReal32 gain)
     {
-        AMPLIMIX_STORE(&_masterGain, gain);
+        AMPLIMIX_STORE_RELAXED(&_masterGain, gain);
     }
 
     void AmplimixImpl::StopAll()
@@ -814,17 +722,21 @@ namespace SparkyStudios::Audio::Amplitude
         }
     }
 
+    static thread_local bool tl_insideAudioMutex = false;
+
     bool AmplimixImpl::IsInsideThreadMutex() const
     {
-        if (const AmUInt64 threadId = Thread::GetCurrentThreadId(); _insideAudioThreadMutex.contains(threadId))
-            return _insideAudioThreadMutex.at(threadId);
-
-        return false;
+        return tl_insideAudioMutex;
     }
 
     void AmplimixImpl::PushCommand(const MixerCommand& command)
     {
-        _commandsStack.push(command);
+        if (!_commandsStack.TryEnqueue(command))
+        {
+            amLogWarning("Amplimix command queue full, executing command inline.");
+            if (command.callback)
+                command.callback();
+        }
     }
 
     const Pipeline* AmplimixImpl::GetPipeline() const
@@ -844,19 +756,14 @@ namespace SparkyStudios::Audio::Amplitude
 
     void AmplimixImpl::ExecuteCommands()
     {
-        while (!_commandsStack.empty())
-        {
-            if (const auto& command = _commandsStack.front(); command.callback)
+        MixerCommand command;
+        while (_commandsStack.TryDequeue(command))
+            if (command.callback)
                 AM_UNUSED(command.callback());
-
-            _commandsStack.pop();
-        }
     }
 
     void AmplimixImpl::MixLayer(AmplimixLayerImpl* layer, AudioBuffer* buffer, AmUInt64 frameCount)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         if (layer->snd == nullptr)
         {
             AMPLITUDE_ASSERT(false); // This should technically never appear
@@ -910,7 +817,7 @@ namespace SparkyStudios::Audio::Amplitude
         inSamples = AM_VALUE_ALIGN(inSamples, kProcessedFramesCount);
 #endif // AM_SIMD_INTRINSICS
 
-        SoundChunk* in = layer->_chunkPool.Acquire(inSamples, soundChannels);
+        SoundChunk* in = layer->_chunkPool.Acquire(inSamples, soundChannels, false);
         SoundChunk* transient = layer->_chunkPool.Acquire(outSamples, 1);
         SoundChunk* out = layer->_chunkPool.Acquire(transient->frames, 2);
 
@@ -1048,41 +955,22 @@ namespace SparkyStudios::Audio::Amplitude
         // run callback if reached the end
         if (cursor == layer->end)
         {
-            // We are in the audio thread mutex here
-            const MixerCommandCallback callback = [this, layer, loop]() -> bool
+            if (!loop)
             {
-                // stop playback unless looping
-                if (!loop)
-                {
-                    OnSoundEnded(this, layer);
-                }
+                OnSoundEnded(this, layer);
+            }
+            else
+            {
+                if (ShouldLoopSound(this, layer))
+                    AMPLIMIX_CSWAP(&layer->cursor, &layer->end, layer->start);
                 else
-                {
-                    // call the onLoop callback
-                    if (ShouldLoopSound(this, layer))
-                    {
-                        // wrap around if allowed looping again
-                        AMPLIMIX_CSWAP(&layer->cursor, &layer->end, layer->start);
-                    }
-                    else
-                    {
-                        // stop playback
-                        OnSoundEnded(this, layer);
-                    }
-                }
-
-                return true;
-            };
-
-            // Postpone call outside the audio thread mutex
-            PushCommand({ callback });
+                    OnSoundEnded(this, layer);
+            }
         }
     }
 
     void AmplimixImpl::MixLayerSeparateMode(AmplimixLayerImpl* layer, AudioBuffer* buffer, AmUInt64 frameCount)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         if (layer->instanceData.empty())
             return;
 
@@ -1126,7 +1014,7 @@ namespace SparkyStudios::Audio::Amplitude
         auto& instances = channel.GetState()->GetInstances();
 
         // Pre-allocate buffers for instance processing
-        SoundChunk* in = layer->_chunkPool.Acquire(inSamples, soundChannels);
+        SoundChunk* in = layer->_chunkPool.Acquire(inSamples, soundChannels, false);
         SoundChunk* transient = layer->_chunkPool.Acquire(outSamples, 1);
         SoundChunk* out = layer->_chunkPool.Acquire(outSamples, 2);
 
@@ -1272,15 +1160,7 @@ namespace SparkyStudios::Audio::Amplitude
 
         // If all instances finished, trigger end callback
         if (allInstancesFinished && !loop)
-        {
-            const MixerCommandCallback callback = [this, layer]() -> bool
-            {
-                OnSoundEnded(this, layer);
-                return true;
-            };
-
-            PushCommand({ callback });
-        }
+            OnSoundEnded(this, layer);
     }
 
     AmplimixLayerImpl* AmplimixImpl::GetLayer(AmUInt32 layer)
@@ -1289,10 +1169,31 @@ namespace SparkyStudios::Audio::Amplitude
         return &_layers[layer & kAmplimixLayersMask];
     }
 
+    AmUInt32 AmplimixImpl::GetLayerIndex(const AmplimixLayerImpl* layer) const
+    {
+        return static_cast<AmUInt32>(layer - _layers);
+    }
+
+    void AmplimixImpl::ActivateLayer(AmUInt32 layerIndex)
+    {
+        _activeLayerIndices[_activeLayerCount++] = layerIndex;
+    }
+
+    void AmplimixImpl::DeactivateLayer(AmUInt32 layerIndex)
+    {
+        for (AmUInt32 i = 0; i < _activeLayerCount; ++i)
+        {
+            if (_activeLayerIndices[i] == layerIndex)
+            {
+                // Swap with last element for O(1) removal
+                _activeLayerIndices[i] = _activeLayerIndices[--_activeLayerCount];
+                return;
+            }
+        }
+    }
+
     bool AmplimixImpl::ShouldMix(AmplimixLayerImpl* layer)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         if (layer->snd == nullptr)
             return false;
 
@@ -1305,8 +1206,6 @@ namespace SparkyStudios::Audio::Amplitude
 
     void AmplimixImpl::UpdatePitch(AmplimixLayerImpl* layer)
     {
-        AmplimixLayerMutexLocker lock(layer);
-
         const AmReal32 pitch = AMPLIMIX_LOAD(&layer->pitch);
         const AmReal32 speed = AMPLIMIX_LOAD(&layer->userPlaySpeed);
 
@@ -1336,15 +1235,14 @@ namespace SparkyStudios::Audio::Amplitude
     void AmplimixImpl::LockAudioMutex()
     {
         _audioThreadMutex.lock();
-        _insideAudioThreadMutex.insert_or_assign(Thread::GetCurrentThreadId(), true);
+        tl_insideAudioMutex = true;
     }
 
     void AmplimixImpl::UnlockAudioMutex()
     {
         AMPLITUDE_ASSERT(IsInsideThreadMutex());
-
+        tl_insideAudioMutex = false;
         _audioThreadMutex.unlock();
-        _insideAudioThreadMutex.insert_or_assign(Thread::GetCurrentThreadId(), false);
     }
 
     void AmplimixImpl::Wait()
@@ -1363,11 +1261,29 @@ namespace SparkyStudios::Audio::Amplitude
     }
 
     AmplimixLayerImpl::~AmplimixLayerImpl()
-    {}
-
-    void AmplimixLayerImpl::Reset()
     {
-        ampooldelete(eMemoryPoolKind_Amplimix, AudioConverter, dataConverter);
+        Destroy();
+    }
+
+    void AmplimixLayerImpl::Destroy()
+    {
+        if (dataConverter != nullptr)
+        {
+            ampooldelete(eMemoryPoolKind_Amplimix, AudioConverter, dataConverter);
+            dataConverter = nullptr;
+        }
+
+        pipeline = nullptr;
+
+        if (snd != nullptr)
+        {
+            snd->sound.reset();
+            snd = nullptr;
+        }
+
+        _chunkPool.Reset();
+
+        AMPLIMIX_STORE(&flag, ePSF_MIN);
     }
 
     void AmplimixLayerImpl::ResetPipeline()
@@ -1402,32 +1318,32 @@ namespace SparkyStudios::Audio::Amplitude
 
     AmUInt64 AmplimixLayerImpl::GetCurrentPosition() const
     {
-        return AMPLIMIX_LOAD(&cursor);
+        return AMPLIMIX_LOAD_RELAXED(&cursor);
     }
 
     AmReal32 AmplimixLayerImpl::GetGain() const
     {
-        return AMPLIMIX_LOAD(&gain);
+        return AMPLIMIX_LOAD_RELAXED(&gain);
     }
 
     AmReal32 AmplimixLayerImpl::GetPitch() const
     {
-        return AMPLIMIX_LOAD(&pitch);
+        return AMPLIMIX_LOAD_RELAXED(&pitch);
     }
 
     AmReal32 AmplimixLayerImpl::GetObstruction() const
     {
-        return AMPLIMIX_LOAD(&obstruction);
+        return AMPLIMIX_LOAD_RELAXED(&obstruction);
     }
 
     AmReal32 AmplimixLayerImpl::GetOcclusion() const
     {
-        return AMPLIMIX_LOAD(&occlusion);
+        return AMPLIMIX_LOAD_RELAXED(&occlusion);
     }
 
     AmReal32 AmplimixLayerImpl::GetPlaySpeed() const
     {
-        return AMPLIMIX_LOAD(&playSpeed);
+        return AMPLIMIX_LOAD_RELAXED(&playSpeed);
     }
 
     AmVector3 AmplimixLayerImpl::GetLocation() const
@@ -1545,7 +1461,7 @@ namespace SparkyStudios::Audio::Amplitude
         if (snd == nullptr || snd->sound == nullptr)
             return 0;
 
-        const AmReal32 ratio = AMPLIMIX_LOAD(&sampleRateRatio);
+        const AmReal32 ratio = AMPLIMIX_LOAD_RELAXED(&sampleRateRatio);
         return snd->format.GetSampleRate() * ratio;
     }
 
@@ -1616,8 +1532,6 @@ namespace SparkyStudios::Audio::Amplitude
 
     void AmplimixLayerImpl::UpdateInstanceData()
     {
-        AmplimixLayerMutexLocker lock(this);
-
         instanceData.clear();
 
         if (snd == nullptr || snd->sound == nullptr)

--- a/src/Mixer/Amplimix.cpp
+++ b/src/Mixer/Amplimix.cpp
@@ -77,6 +77,15 @@ namespace SparkyStudios::Audio::Amplitude
 
     static void OnSoundDestroyed(AmplimixImpl* mixer, AmplimixLayerImpl* layer);
 
+    static void TriggerChannelEvents(ChannelInternalState* channelState, eChannelEvent event)
+    {
+        amEngine->OnNextFrame(
+            [channelState, event](AmTime)
+            {
+                channelState->Trigger(event);
+            });
+    }
+
     static bool ShouldLoopSound(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         const auto* sound = layer->snd->sound.get();
@@ -88,51 +97,51 @@ namespace SparkyStudios::Audio::Amplitude
     static void OnSoundStarted(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         const auto* sound = layer->snd->sound.get();
-        amLogDebug("Started sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetPath().c_str());
+        amLogDebug("Started sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetName().c_str());
 
         const auto channel = sound->GetChannel();
         auto* channelState = channel.GetState();
 
-        channelState->Trigger(eChannelEvent_Begin);
+        TriggerChannelEvents(channelState, eChannelEvent_Begin);
     }
 
     static void OnSoundPaused(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         const auto* sound = layer->snd->sound.get();
-        amLogDebug("Paused sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetPath().c_str());
+        amLogDebug("Paused sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetName().c_str());
 
         const auto channel = sound->GetChannel();
         auto* channelState = channel.GetState();
 
-        channelState->Trigger(eChannelEvent_Pause);
+        TriggerChannelEvents(channelState, eChannelEvent_Pause);
     }
 
     static void OnSoundResumed(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         const auto* sound = layer->snd->sound.get();
-        amLogDebug("Resumed sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetPath().c_str());
+        amLogDebug("Resumed sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetName().c_str());
 
         const auto channel = sound->GetChannel();
         auto* channelState = channel.GetState();
 
-        channelState->Trigger(eChannelEvent_Resume);
+        TriggerChannelEvents(channelState, eChannelEvent_Resume);
     }
 
     static void OnSoundStopped(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         const auto* sound = layer->snd->sound.get();
-        amLogDebug("Stopped sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetPath().c_str());
+        amLogDebug("Stopped sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetName().c_str());
 
         const auto channel = sound->GetChannel();
         auto* channelState = channel.GetState();
 
-        channelState->Trigger(eChannelEvent_Stop);
+        TriggerChannelEvents(channelState, eChannelEvent_Stop);
     }
 
     static bool OnSoundLooped(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         auto* sound = layer->snd->sound.get();
-        amLogDebug("Looped sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetPath().c_str());
+        amLogDebug("Looped sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetName().c_str());
 
         AmplimixImpl::IncrementSoundLoopCount(sound);
 
@@ -143,7 +152,7 @@ namespace SparkyStudios::Audio::Amplitude
             const auto channel = sound->GetChannel();
             auto* channelState = channel.GetState();
 
-            channelState->Trigger(eChannelEvent_Loop);
+            TriggerChannelEvents(channelState, eChannelEvent_Loop);
         }
 
         return shouldLoop;
@@ -161,52 +170,32 @@ namespace SparkyStudios::Audio::Amplitude
     static void OnSoundEnded(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         auto* sound = layer->snd->sound.get();
-        amLogDebug("Ended sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetPath().c_str());
+        amLogDebug("Ended sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetName().c_str());
 
         const auto channel = sound->GetChannel();
         auto* channelState = channel.GetState();
 
-        if (const auto* engine = static_cast<const EngineImpl*>(Engine::GetInstance()); engine->GetState()->stopping)
+        auto haltCallback = [channelState]() -> bool
         {
-            // Stop playing the sound
+            TriggerChannelEvents(channelState, eChannelEvent_End);
             channelState->HaltInternal();
 
-            channelState->Trigger(eChannelEvent_End);
+            return true;
+        };
 
-            mixer->PushCommand({ [mixer, layer]() -> bool
-                                 {
-                                     OnSoundDestroyed(mixer, layer);
-                                     return true;
-                                 } });
-
+        if (const auto* engine = static_cast<const EngineImpl*>(Engine::GetInstance()); engine->GetState()->stopping)
+        {
+            mixer->PushCommand({ haltCallback });
             return;
         }
 
         if (sound->GetSettings().m_kind == SoundKind::Standalone)
         {
-            // Stop playing the sound
-            channelState->HaltInternal();
-
-            channelState->Trigger(eChannelEvent_End);
-
-            mixer->PushCommand({ [mixer, layer]() -> bool
-                                 {
-                                     OnSoundDestroyed(mixer, layer);
-                                     return true;
-                                 } });
+            mixer->PushCommand({ haltCallback });
         }
         else if (sound->GetSettings().m_kind == SoundKind::Switched)
         {
-            // Stop playing the sound
-            channelState->HaltInternal();
-
-            channelState->Trigger(eChannelEvent_End);
-
-            mixer->PushCommand({ [mixer, layer]() -> bool
-                                 {
-                                     OnSoundDestroyed(mixer, layer);
-                                     return true;
-                                 } });
+            mixer->PushCommand({ haltCallback });
         }
         else if (sound->GetSettings().m_kind == SoundKind::Contained)
         {
@@ -215,31 +204,20 @@ namespace SparkyStudios::Audio::Amplitude
 
             if (const CollectionDefinition* config = collection->GetDefinition(); config->play_mode() == CollectionPlayMode_PlayAll)
             {
-                if (channelState->Valid())
-                {
-                    channelState->GetRealChannel().MarkAsPlayed(sound->GetSound());
-                    if (channelState->GetRealChannel().AllSoundsHasPlayed())
+                amEngine->OnNextFrame(
+                    [collection, channelState, sound, mixer, haltCallback](AmTime)
                     {
-                        channelState->GetRealChannel().ClearPlayedSounds();
-                        if (config->play_mode() == CollectionPlayMode_PlayAll)
+                        channelState->GetRealChannel().MarkAsPlayed(sound->GetSound());
+                        if (channelState->GetRealChannel().AllSoundsHasPlayed())
                         {
-                            // Stop playing the collection
-                            channelState->HaltInternal();
-
-                            channelState->Trigger(eChannelEvent_End);
+                            channelState->GetRealChannel().ClearPlayedSounds();
+                            mixer->PushCommand({ haltCallback });
                         }
-                    }
 
-                    // Play the collection again only if the channel is still playing.
-                    if (channelState->GetRealChannel().Playing())
-                        channelState->Play();
-                }
-
-                mixer->PushCommand({ [mixer, layer]() -> bool
-                                     {
-                                         OnSoundDestroyed(mixer, layer);
-                                         return true;
-                                     } });
+                        // Play the collection again only if the channel is still playing.
+                        if (channelState->GetRealChannel().Playing())
+                            channelState->Play();
+                    });
             }
         }
         else
@@ -332,6 +310,9 @@ namespace SparkyStudios::Audio::Amplitude
 
         // Drain any pending deferred commands
         ExecuteCommands();
+
+        for (auto& layer : _layers)
+            layer.Destroy();
 
         _initialized = false;
         _pipeline = nullptr;
@@ -760,22 +741,24 @@ namespace SparkyStudios::Audio::Amplitude
         if (_commandsStack.TryEnqueue(command))
             return;
 
-        // Spin briefly — the audio thread drains at callback rate (~5ms)
-        for (int i = 0; i < 256; ++i)
+        if (!IsInsideThreadMutex())
         {
-            std::this_thread::yield();
+            // Spin briefly — the audio thread drains at callback rate (~5ms)
+            for (int i = 0; i < 256; ++i)
+            {
+                std::this_thread::yield();
+                if (_commandsStack.TryEnqueue(command))
+                    return;
+            }
+
+            // Wait for the current mix cycle to finish (drains the queue)
+            amLogWarning("Amplimix command queue full, waiting for mix cycle to drain.");
+            Wait();
+
             if (_commandsStack.TryEnqueue(command))
                 return;
         }
 
-        // Wait for the current mix cycle to finish (drains the queue)
-        amLogWarning("Amplimix command queue full, waiting for mix cycle to drain.");
-        Wait();
-
-        if (_commandsStack.TryEnqueue(command))
-            return;
-
-        // Last resort: Mix() is confirmed idle (Wait returned), so inline is safe.
         amLogWarning("Amplimix command queue still full after wait. Executing command inline (mixer idle).");
         if (command.callback)
             command.callback();

--- a/src/Mixer/Amplimix.cpp
+++ b/src/Mixer/Amplimix.cpp
@@ -1211,12 +1211,14 @@ namespace SparkyStudios::Audio::Amplitude
 
     void AmplimixImpl::DeactivateLayer(AmUInt32 layerIndex)
     {
-        for (AmUInt32 i = 0; i < _activeLayerCount; ++i)
+        AmUInt32 activeLayerCount = AMPLIMIX_LOAD_RELAXED(&_activeLayerCount);
+        for (AmUInt32 i = 0; i < activeLayerCount; ++i)
         {
             if (_activeLayerIndices[i] == layerIndex)
             {
                 // Swap with last element for O(1) removal
-                _activeLayerIndices[i] = _activeLayerIndices[--_activeLayerCount];
+                _activeLayerIndices[i] = _activeLayerIndices[--activeLayerCount];
+                AMPLIMIX_STORE_RELAXED(&_activeLayerCount, activeLayerCount);
                 return;
             }
         }

--- a/src/Mixer/Amplimix.cpp
+++ b/src/Mixer/Amplimix.cpp
@@ -97,7 +97,7 @@ namespace SparkyStudios::Audio::Amplitude
     static void OnSoundStarted(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         const auto* sound = layer->snd->sound.get();
-        amLogDebug("Started sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetName().c_str());
+        amLogDebug("Started sound: '%s'.", sound->GetSound()->GetName().c_str());
 
         const auto channel = sound->GetChannel();
         auto* channelState = channel.GetState();
@@ -108,7 +108,7 @@ namespace SparkyStudios::Audio::Amplitude
     static void OnSoundPaused(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         const auto* sound = layer->snd->sound.get();
-        amLogDebug("Paused sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetName().c_str());
+        amLogDebug("Paused sound: '%s'.", sound->GetSound()->GetName().c_str());
 
         const auto channel = sound->GetChannel();
         auto* channelState = channel.GetState();
@@ -119,7 +119,7 @@ namespace SparkyStudios::Audio::Amplitude
     static void OnSoundResumed(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         const auto* sound = layer->snd->sound.get();
-        amLogDebug("Resumed sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetName().c_str());
+        amLogDebug("Resumed sound: '%s'.", sound->GetSound()->GetName().c_str());
 
         const auto channel = sound->GetChannel();
         auto* channelState = channel.GetState();
@@ -130,7 +130,7 @@ namespace SparkyStudios::Audio::Amplitude
     static void OnSoundStopped(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         const auto* sound = layer->snd->sound.get();
-        amLogDebug("Stopped sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetName().c_str());
+        amLogDebug("Stopped sound: '%s'.", sound->GetSound()->GetName().c_str());
 
         const auto channel = sound->GetChannel();
         auto* channelState = channel.GetState();
@@ -141,7 +141,7 @@ namespace SparkyStudios::Audio::Amplitude
     static bool OnSoundLooped(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         auto* sound = layer->snd->sound.get();
-        amLogDebug("Looped sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetName().c_str());
+        amLogDebug("Looped sound: '%s'.", sound->GetSound()->GetName().c_str());
 
         AmplimixImpl::IncrementSoundLoopCount(sound);
 
@@ -170,7 +170,7 @@ namespace SparkyStudios::Audio::Amplitude
     static void OnSoundEnded(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
         auto* sound = layer->snd->sound.get();
-        amLogDebug("Ended sound: '" AM_OS_CHAR_FMT "'.", sound->GetSound()->GetName().c_str());
+        amLogDebug("Ended sound: '%s'.", sound->GetSound()->GetName().c_str());
 
         const auto channel = sound->GetChannel();
         auto* channelState = channel.GetState();

--- a/src/Mixer/Amplimix.cpp
+++ b/src/Mixer/Amplimix.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <thread>
+
 #include <SparkyStudios/Audio/Amplitude/Amplitude.h>
 
 #include <Core/Engine.h>
@@ -248,6 +250,9 @@ namespace SparkyStudios::Audio::Amplitude
 
     static void OnSoundDestroyed(AmplimixImpl* mixer, AmplimixLayerImpl* layer)
     {
+        // Null guard: multiple deferred commands may target the same layer in one
+        // ExecuteCommands() pass (e.g., HaltInternal queues via SetPlayState + OnSoundEnded
+        // queues another). The first call nulls snd via Destroy(); subsequent calls are no-ops.
         if (layer->snd == nullptr)
             return;
 
@@ -486,7 +491,9 @@ namespace SparkyStudios::Audio::Amplitude
             // Initialize this layer's pipeline
             lay->pipeline = _pipeline->CreateInstance(lay);
 
-            // fill in non-atomic layer data along with truncating start and end
+            // All non-atomic writes (id, snd, start, end) happen before the release-store
+            // to lay->flag below. The audio thread's acquire-load on flag in ShouldMix()
+            // establishes happens-before, guaranteeing these fields are visible.
             lay->id = id;
             lay->snd = sound;
 
@@ -749,12 +756,29 @@ namespace SparkyStudios::Audio::Amplitude
 
     void AmplimixImpl::PushCommand(const MixerCommand& command)
     {
-        if (!_commandsStack.TryEnqueue(command))
+        // Fast path
+        if (_commandsStack.TryEnqueue(command))
+            return;
+
+        // Spin briefly — the audio thread drains at callback rate (~5ms)
+        for (int i = 0; i < 256; ++i)
         {
-            amLogWarning("Amplimix command queue full, executing command inline.");
-            if (command.callback)
-                command.callback();
+            std::this_thread::yield();
+            if (_commandsStack.TryEnqueue(command))
+                return;
         }
+
+        // Wait for the current mix cycle to finish (drains the queue)
+        amLogWarning("Amplimix command queue full, waiting for mix cycle to drain.");
+        Wait();
+
+        if (_commandsStack.TryEnqueue(command))
+            return;
+
+        // Last resort: Mix() is confirmed idle (Wait returned), so inline is safe.
+        amLogWarning("Amplimix command queue still full after wait. Executing command inline (mixer idle).");
+        if (command.callback)
+            command.callback();
     }
 
     const Pipeline* AmplimixImpl::GetPipeline() const
@@ -782,6 +806,9 @@ namespace SparkyStudios::Audio::Amplitude
 
     void AmplimixImpl::MixLayer(AmplimixLayerImpl* layer, AudioBuffer* buffer, AmUInt64 frameCount)
     {
+        // snd is guaranteed non-null here: ShouldMix() already verified flag > ePSF_HALT
+        // (acquire), and Destroy() (which nulls snd) only runs in ExecuteCommands() after
+        // this loop. The assert below is a defense-in-depth check.
         if (layer->snd == nullptr)
         {
             AMPLITUDE_ASSERT(false); // This should technically never appear
@@ -1214,14 +1241,18 @@ namespace SparkyStudios::Audio::Amplitude
 
     bool AmplimixImpl::ShouldMix(AmplimixLayerImpl* layer)
     {
-        if (layer->snd == nullptr)
-            return false;
-
-        // load flag value
+        // Acquire-load flag first to establish happens-before with the
+        // release-store in PlayAdvanced (which writes snd before setting flag).
         PlayStateFlag flag = AMPLIMIX_LOAD(&layer->flag);
 
-        // return if flag is not cleared
-        return (flag > ePSF_HALT);
+        if (flag <= ePSF_HALT)
+            return false;
+
+        // After the acquire on flag, snd is guaranteed non-null because:
+        // - PlayAdvanced writes snd before release-storing flag > ePSF_HALT
+        // - Destroy() (which nulls snd) only runs in ExecuteCommands() after the mix loop
+        AMPLITUDE_ASSERT(layer->snd != nullptr);
+        return true;
     }
 
     void AmplimixImpl::UpdatePitch(AmplimixLayerImpl* layer)
@@ -1287,6 +1318,9 @@ namespace SparkyStudios::Audio::Amplitude
 
     void AmplimixLayerImpl::Destroy()
     {
+        // This method runs only inside ExecuteCommands(), which executes after
+        // the mix loop in Mix(). Therefore no audio-thread reads of snd can
+        // race with the null assignment below.
         if (dataConverter != nullptr)
         {
             ampooldelete(eMemoryPoolKind_Amplimix, AudioConverter, dataConverter);

--- a/src/Mixer/Amplimix.cpp
+++ b/src/Mixer/Amplimix.cpp
@@ -171,7 +171,12 @@ namespace SparkyStudios::Audio::Amplitude
 
             channelState->Trigger(eChannelEvent_End);
 
-            OnSoundDestroyed(mixer, layer);
+            mixer->PushCommand({ [mixer, layer]() -> bool
+                                 {
+                                     OnSoundDestroyed(mixer, layer);
+                                     return true;
+                                 } });
+
             return;
         }
 
@@ -182,8 +187,11 @@ namespace SparkyStudios::Audio::Amplitude
 
             channelState->Trigger(eChannelEvent_End);
 
-            // Destroy the sound instance on end
-            OnSoundDestroyed(mixer, layer);
+            mixer->PushCommand({ [mixer, layer]() -> bool
+                                 {
+                                     OnSoundDestroyed(mixer, layer);
+                                     return true;
+                                 } });
         }
         else if (sound->GetSettings().m_kind == SoundKind::Switched)
         {
@@ -192,8 +200,11 @@ namespace SparkyStudios::Audio::Amplitude
 
             channelState->Trigger(eChannelEvent_End);
 
-            // Destroy the sound instance on stop
-            OnSoundDestroyed(mixer, layer);
+            mixer->PushCommand({ [mixer, layer]() -> bool
+                                 {
+                                     OnSoundDestroyed(mixer, layer);
+                                     return true;
+                                 } });
         }
         else if (sound->GetSettings().m_kind == SoundKind::Contained)
         {
@@ -219,13 +230,14 @@ namespace SparkyStudios::Audio::Amplitude
 
                     // Play the collection again only if the channel is still playing.
                     if (channelState->GetRealChannel().Playing())
-                    {
                         channelState->Play();
-                    }
                 }
 
-                // Delete the current sound instance.
-                OnSoundDestroyed(mixer, layer);
+                mixer->PushCommand({ [mixer, layer]() -> bool
+                                     {
+                                         OnSoundDestroyed(mixer, layer);
+                                         return true;
+                                     } });
             }
         }
         else
@@ -319,7 +331,7 @@ namespace SparkyStudios::Audio::Amplitude
         _initialized = false;
         _pipeline = nullptr;
 
-        _activeLayerCount = 0;
+        AMPLIMIX_STORE_RELAXED(&_activeLayerCount, 0);
     }
 
     void AmplimixImpl::UpdateDevice(
@@ -383,7 +395,9 @@ namespace SparkyStudios::Audio::Amplitude
 
         // begin actual mixing
         bool hasMixedAtLeastOneLayer = false;
-        for (AmUInt32 i = 0; i < _activeLayerCount; ++i)
+        const AmUInt32 activeLayerCount = AMPLIMIX_LOAD_RELAXED(&_activeLayerCount);
+
+        for (AmUInt32 i = 0; i < activeLayerCount; ++i)
         {
             if (amEngine->IsStopping())
                 break; // Stop mixing if engine is stopping
@@ -523,8 +537,12 @@ namespace SparkyStudios::Audio::Amplitude
             // store flag last, releasing the layer to the mixer thread
             AMPLIMIX_STORE(&lay->flag, flag);
 
-            // Add to active layer list
-            ActivateLayer(GetLayerIndex(lay));
+            PushCommand({ [this, lay]() -> bool
+                          {
+                              // Add to active layer list
+                              ActivateLayer(GetLayerIndex(lay));
+                              return true;
+                          } });
 
             OnSoundStarted(this, lay);
         }
@@ -1176,7 +1194,9 @@ namespace SparkyStudios::Audio::Amplitude
 
     void AmplimixImpl::ActivateLayer(AmUInt32 layerIndex)
     {
-        _activeLayerIndices[_activeLayerCount++] = layerIndex;
+        AmUInt32 activeLayerCount = AMPLIMIX_LOAD_RELAXED(&_activeLayerCount);
+        _activeLayerIndices[activeLayerCount++] = layerIndex;
+        AMPLIMIX_STORE_RELAXED(&_activeLayerCount, activeLayerCount);
     }
 
     void AmplimixImpl::DeactivateLayer(AmUInt32 layerIndex)

--- a/src/Mixer/Amplimix.h
+++ b/src/Mixer/Amplimix.h
@@ -291,7 +291,7 @@ namespace SparkyStudios::Audio::Amplitude
 
         bool _initialized;
 
-        MPSCQueue<MixerCommand, 512> _commandsStack;
+        MPSCQueue<MixerCommand, kAmplimixLayersCount> _commandsStack;
 
         std::recursive_timed_mutex _audioThreadMutex;
 

--- a/src/Mixer/Amplimix.h
+++ b/src/Mixer/Amplimix.h
@@ -19,10 +19,10 @@
 
 #include <condition_variable>
 #include <mutex>
-#include <queue>
 
 #include <SparkyStudios/Audio/Amplitude/Core/Common.h>
 #include <SparkyStudios/Audio/Amplitude/Core/Device.h>
+#include <SparkyStudios/Audio/Amplitude/Core/MPSCQueue.h>
 #include <SparkyStudios/Audio/Amplitude/Core/Thread.h>
 #include <SparkyStudios/Audio/Amplitude/DSP/AudioConverter.h>
 #include <SparkyStudios/Audio/Amplitude/Mixer/Amplimix.h>
@@ -34,8 +34,6 @@
 #include <Utils/Utils.h>
 
 #include "engine_config_definition_generated.h"
-
-#define _Atomic(X) std::atomic<X>
 
 namespace SparkyStudios::Audio::Amplitude
 {
@@ -64,35 +62,37 @@ namespace SparkyStudios::Audio::Amplitude
     {
     public:
         AmUInt32 id = kAmInvalidObjectId; // playing id
-        _Atomic(PlayStateFlag) flag; // state
-        _Atomic(AmUInt64) cursor; // cursor
-        _Atomic(AmReal32) gain; // gain
-        _Atomic(AmReal32) pitch; // pitch
+        std::atomic<PlayStateFlag> flag; // state
+        std::atomic<AmUInt64> cursor; // cursor
+        std::atomic<AmReal32> gain; // gain
+        std::atomic<AmReal32> pitch; // pitch
         SoundData* snd = nullptr; // sound data
         AmUInt64 start = 0, end = 0; // start and end frames
 
-        _Atomic(AmReal32) obstruction; // obstruction factor
-        _Atomic(AmReal32) occlusion; // occlusion factor
+        std::atomic<AmReal32> obstruction; // obstruction factor
+        std::atomic<AmReal32> occlusion; // occlusion factor
 
-        _Atomic(AmReal32) userPlaySpeed; // user-defined sound playback speed
-        _Atomic(AmReal32) playSpeed; // current sound playback speed
-        _Atomic(AmReal32) targetPlaySpeed; // computed (real) sound playback speed
-        _Atomic(AmReal32) sampleRateRatio; // sample rate ratio
-        _Atomic(AmReal32) baseSampleRateRatio; // base sample rate ratio
+        std::atomic<AmReal32> userPlaySpeed; // user-defined sound playback speed
+        std::atomic<AmReal32> playSpeed; // current sound playback speed
+        std::atomic<AmReal32> targetPlaySpeed; // computed (real) sound playback speed
+        std::atomic<AmReal32> sampleRateRatio; // sample rate ratio
+        std::atomic<AmReal32> baseSampleRateRatio; // base sample rate ratio
 
         AudioConverter* dataConverter = nullptr; // miniaudio resampler & channel converter
         std::shared_ptr<PipelineInstance> pipeline = nullptr; // pipeline for this layer
-
-        std::recursive_mutex mutex; // mutex for thread-safe access
 
         SoundChunkPool _chunkPool; // pool for reusable SoundChunk allocations
 
         ~AmplimixLayerImpl() override;
 
         /**
-         * @brief Resets the layer.
+         * @brief Destroys the layer's pipeline and sound reference.
+         *
+         * Releases the pipeline instance and the sound data pointer,
+         * then sets the layer flag to ePSF_MIN. Safe to call even if
+         * the layer has no sound attached.
          */
-        void Reset();
+        void Destroy();
 
         /**
          * @brief Resets the pipeline to its initial state.
@@ -272,6 +272,10 @@ namespace SparkyStudios::Audio::Amplitude
 
         static void IncrementSoundLoopCount(SoundInstance* sound);
 
+        AmUInt32 GetLayerIndex(const AmplimixLayerImpl* layer) const;
+        void ActivateLayer(AmUInt32 layerIndex);
+        void DeactivateLayer(AmUInt32 layerIndex);
+
     private:
         friend class EngineImpl;
 
@@ -287,23 +291,28 @@ namespace SparkyStudios::Audio::Amplitude
 
         bool _initialized;
 
-        std::queue<MixerCommand> _commandsStack;
+        MPSCQueue<MixerCommand, 512> _commandsStack;
 
         std::recursive_timed_mutex _audioThreadMutex;
-        std::unordered_map<AmThreadID, bool> _insideAudioThreadMutex;
 
-        _Atomic(bool) _isMixing{ false };
+        std::atomic<bool> _isMixing{ false };
         std::mutex _mixCompleteMutex;
         std::condition_variable _mixCompleteCV;
 
         AmUInt32 _nextId;
-        _Atomic(AmReal32) _masterGain{};
+        std::atomic<AmReal32> _masterGain{};
         AmplimixLayerImpl _layers[kAmplimixLayersCount];
+        AmUInt32 _activeLayerIndices[kAmplimixLayersCount];
+        AmUInt32 _activeLayerCount = 0;
         AmUInt64 _remainingFrames;
 
         Pipeline* _pipeline = nullptr;
 
         DeviceDescription _device;
+
+        // Atomic snapshots of device fields read by the audio thread.
+        std::atomic<AmUInt32> _mixOutputSampleRate{};
+        std::atomic<PlaybackOutputChannels> _mixOutputChannels{};
 
         AudioBuffer _scratchBuffer;
 

--- a/src/Mixer/Amplimix.h
+++ b/src/Mixer/Amplimix.h
@@ -303,7 +303,7 @@ namespace SparkyStudios::Audio::Amplitude
         std::atomic<AmReal32> _masterGain{};
         AmplimixLayerImpl _layers[kAmplimixLayersCount];
         AmUInt32 _activeLayerIndices[kAmplimixLayersCount];
-        AmUInt32 _activeLayerCount = 0;
+        std::atomic<AmUInt32> _activeLayerCount = 0;
         AmUInt64 _remainingFrames;
 
         Pipeline* _pipeline = nullptr;

--- a/src/Mixer/Node.cpp
+++ b/src/Mixer/Node.cpp
@@ -113,6 +113,7 @@ namespace SparkyStudios::Audio::Amplitude
         , _processingBuffer(nullptr)
         , _lastOutputBuffer(nullptr)
         , _processOnEmptyInputBuffer(processOnEmptyInputBuffer)
+        , _cachedProvider(nullptr)
     {}
 
     void ProcessorNodeInstance::Consume()
@@ -122,18 +123,22 @@ namespace SparkyStudios::Audio::Amplitude
 
         AMPLITUDE_ASSERT(m_provider != kAmInvalidObjectId);
 
-        const auto node = m_pipeline->GetNode(m_provider);
-        AMPLITUDE_ASSERT(node != nullptr);
+        if (_cachedProvider == nullptr)
+        {
+            const auto node = m_pipeline->GetNode(m_provider);
+            AMPLITUDE_ASSERT(node != nullptr);
 
-        const auto provider = std::dynamic_pointer_cast<ProviderNodeInstance>(node);
-        AMPLITUDE_ASSERT(provider != nullptr);
+            _cachedProvider = dynamic_cast<ProviderNodeInstance*>(node.get());
+            AMPLITUDE_ASSERT(_cachedProvider != nullptr);
+        }
 
-        _processingBuffer = provider->Provide();
+        _processingBuffer = _cachedProvider->Provide();
     }
 
     void ProcessorNodeInstance::Connect(AmObjectID provider)
     {
         m_provider = provider;
+        _cachedProvider = nullptr;
     }
 
     const AudioBuffer* ProcessorNodeInstance::Provide()
@@ -178,6 +183,7 @@ namespace SparkyStudios::Audio::Amplitude
         : _processingBuffers()
         , _mixBuffer()
         , _processed(false)
+        , _cachedProviders()
     {}
 
     void MixerNodeInstance::Consume()
@@ -188,29 +194,38 @@ namespace SparkyStudios::Audio::Amplitude
         if (m_providers.empty())
             return;
 
-        _processingBuffers.clear();
-        for (const auto& providerId : m_providers)
+        if (_cachedProviders.empty())
         {
-            AMPLITUDE_ASSERT(providerId != kAmInvalidObjectId);
+            _cachedProviders.reserve(m_providers.size());
+            for (const auto& providerId : m_providers)
+            {
+                AMPLITUDE_ASSERT(providerId != kAmInvalidObjectId);
 
-            auto node = m_pipeline->GetNode(providerId);
-            AMPLITUDE_ASSERT(node != nullptr);
+                auto node = m_pipeline->GetNode(providerId);
+                AMPLITUDE_ASSERT(node != nullptr);
 
-            auto provider = std::dynamic_pointer_cast<ProviderNodeInstance>(node);
-            AMPLITUDE_ASSERT(provider != nullptr);
+                auto* provider = dynamic_cast<ProviderNodeInstance*>(node.get());
+                AMPLITUDE_ASSERT(provider != nullptr);
 
-            _processingBuffers.push_back(provider->Provide());
+                _cachedProviders.push_back(provider);
+            }
         }
+
+        _processingBuffers.clear();
+        for (auto* provider : _cachedProviders)
+            _processingBuffers.push_back(provider->Provide());
     }
 
     void MixerNodeInstance::Connect(AmObjectID provider)
     {
         m_providers.push_back(provider);
+        _cachedProviders.clear();
     }
 
     void MixerNodeInstance::Connect(const std::vector<AmObjectID>& providers)
     {
         m_providers = providers;
+        _cachedProviders.clear();
     }
 
     const AudioBuffer* MixerNodeInstance::Provide()
@@ -304,6 +319,7 @@ namespace SparkyStudios::Audio::Amplitude
     OutputNodeInstance::OutputNodeInstance()
         : _provider(0)
         , _buffer(nullptr)
+        , _cachedProvider(nullptr)
     {}
 
     void OutputNodeInstance::SetOutput(AudioBuffer* buffer)
@@ -314,6 +330,7 @@ namespace SparkyStudios::Audio::Amplitude
     void OutputNodeInstance::Connect(AmObjectID provider)
     {
         _provider = provider;
+        _cachedProvider = nullptr;
     }
 
     void OutputNodeInstance::Consume()
@@ -326,13 +343,16 @@ namespace SparkyStudios::Audio::Amplitude
 
         AMPLITUDE_ASSERT(_provider != kAmInvalidObjectId);
 
-        auto node = m_pipeline->GetNode(_provider);
-        AMPLITUDE_ASSERT(node != nullptr);
+        if (_cachedProvider == nullptr)
+        {
+            auto node = m_pipeline->GetNode(_provider);
+            AMPLITUDE_ASSERT(node != nullptr);
 
-        const auto provider = std::dynamic_pointer_cast<ProviderNodeInstance>(node);
-        AMPLITUDE_ASSERT(provider != nullptr);
+            _cachedProvider = dynamic_cast<ProviderNodeInstance*>(node.get());
+            AMPLITUDE_ASSERT(_cachedProvider != nullptr);
+        }
 
-        const auto* output = provider->Provide();
+        const auto* output = _cachedProvider->Provide();
         if (output == nullptr)
             return;
 

--- a/src/Mixer/Pipeline.cpp
+++ b/src/Mixer/Pipeline.cpp
@@ -64,8 +64,8 @@ namespace SparkyStudios::Audio::Amplitude
 
     std::shared_ptr<NodeInstance> PipelineInstanceImpl::GetNode(AmObjectID id) const
     {
-        if (_nodeInstances.contains(id))
-            return _nodeInstances.at(id).second;
+        if (const auto it = _nodeInstances.find(id); it != _nodeInstances.end())
+            return it->second.second;
 
         if (_inputNode != nullptr && _inputNode->GetId() == id)
             return _inputNode;

--- a/src/Mixer/Pipeline.cpp
+++ b/src/Mixer/Pipeline.cpp
@@ -44,12 +44,12 @@ namespace SparkyStudios::Audio::Amplitude
             _inputNode = nullptr;
     }
 
-    void PipelineInstanceImpl::Execute(const AudioBuffer& in, AudioBuffer& out)
+    void PipelineInstanceImpl::Execute(AudioBuffer& in, AudioBuffer& out)
     {
         // Auto-configure if buffer dimensions changed
         Configure(in.GetFrameCount(), in.GetChannelCount(), out.GetFrameCount(), out.GetChannelCount());
 
-        _inputNode->SetInput(const_cast<AudioBuffer*>(&in));
+        _inputNode->SetInput(&in);
         _outputNode->SetOutput(&out);
 
         // Consume data from the output node.

--- a/src/Mixer/Pipeline.cpp
+++ b/src/Mixer/Pipeline.cpp
@@ -49,11 +49,7 @@ namespace SparkyStudios::Audio::Amplitude
         // Auto-configure if buffer dimensions changed
         Configure(in.GetFrameCount(), in.GetChannelCount(), out.GetFrameCount(), out.GetChannelCount());
 
-        // Copy the input buffer content
-        _inputBuffer = in;
-
-        // Set the input and output buffers for the pipeline
-        _inputNode->SetInput(&_inputBuffer);
+        _inputNode->SetInput(const_cast<AudioBuffer*>(&in));
         _outputNode->SetOutput(&out);
 
         // Consume data from the output node.

--- a/src/Mixer/Pipeline.h
+++ b/src/Mixer/Pipeline.h
@@ -35,7 +35,7 @@ namespace SparkyStudios::Audio::Amplitude
 
         ~PipelineInstanceImpl() override;
 
-        void Execute(const AudioBuffer& inputBuffer, AudioBuffer& outputBuffer) override;
+        void Execute(AudioBuffer& inputBuffer, AudioBuffer& outputBuffer) override;
 
         std::shared_ptr<NodeInstance> GetNode(AmObjectID id) const override;
 

--- a/src/Mixer/Pipeline.h
+++ b/src/Mixer/Pipeline.h
@@ -63,7 +63,6 @@ namespace SparkyStudios::Audio::Amplitude
         std::shared_ptr<OutputNodeInstance> _outputNode;
 
         const AmplimixLayerImpl* _layer;
-        AudioBuffer _inputBuffer;
 
         // Configuration caching state
         AmUInt64 _configuredInputFrameCount = 0;

--- a/src/Mixer/RealChannel.cpp
+++ b/src/Mixer/RealChannel.cpp
@@ -36,14 +36,11 @@ namespace SparkyStudios::Audio::Amplitude
 
     RealChannel::RealChannel(ChannelInternalState* parent)
         : _channelId(kAmInvalidObjectId)
-        , _channelLayersId()
-        , _stream()
-        , _loop()
-        , _gain()
+        , _layers()
+        , _defaultGain(1.0f)
         , _pitch(1.0f)
         , _playSpeed(1.0f)
         , _mixer(nullptr)
-        , _activeSounds()
         , _parentChannelState(parent)
         , _playedSounds()
     {}
@@ -102,7 +99,7 @@ namespace SparkyStudios::Audio::Amplitude
             return false;
 
         bool success = true;
-        AmUInt32 layer = FindFreeLayer(_channelLayersId.empty() ? 1 : _channelLayersId.begin()->first);
+        AmUInt32 layer = FindFreeLayer(_layers.empty() ? 1 : _layers.begin()->first);
         std::vector<AmUInt32> layers;
 
         for (auto& instance : instances)
@@ -128,31 +125,32 @@ namespace SparkyStudios::Audio::Amplitude
     {
         AMPLITUDE_ASSERT(sound != nullptr);
 
-        _activeSounds[layer] = sound;
-        _activeSounds[layer]->SetChannel(this);
-        _activeSounds[layer]->Load();
+        LayerData& data = _layers[layer];
+        data.soundInstance = sound;
+        data.soundInstance->SetChannel(this);
+        data.soundInstance->Load();
 
         if (sound->GetUserData() == nullptr)
         {
-            _channelLayersId[layer] = kAmInvalidObjectId;
+            data.mixerLayerId = kAmInvalidObjectId;
             amLogError("The sound was not loaded successfully.");
             return false;
         }
 
-        _loop[layer] = sound->GetSound()->IsLoop();
-        _stream[layer] = sound->GetSound()->IsStream();
+        data.isLoop = sound->GetSound()->IsLoop();
+        data.isStream = sound->GetSound()->IsStream();
+        data.gain = _defaultGain;
 
-        const PlayStateFlag loops = _loop[layer] ? ePSF_LOOP : ePSF_PLAY;
+        const PlayStateFlag loops = data.isLoop ? ePSF_LOOP : ePSF_PLAY;
 
-        _channelLayersId[layer] =
+        data.mixerLayerId =
             _mixer->Play(static_cast<SoundData*>(sound->GetUserData()), loops, GetGain(layer), _pitch, _playSpeed, _channelId, 0);
 
-        // Check if playing the sound was successful, and display the error if it was not.
-        const bool success = _channelLayersId[layer] != kAmInvalidObjectId;
+        const bool success = data.mixerLayerId != kAmInvalidObjectId;
         if (!success)
         {
-            _channelLayersId[layer] = kAmInvalidObjectId;
-            amLogError("Could not play sound '" AM_OS_CHAR_FMT "'.", _activeSounds[layer]->GetSound()->GetPath().c_str());
+            data.mixerLayerId = kAmInvalidObjectId;
+            amLogError("Could not play sound '" AM_OS_CHAR_FMT "'.", data.soundInstance->GetSound()->GetPath().c_str());
         }
 
         return success;
@@ -162,17 +160,19 @@ namespace SparkyStudios::Audio::Amplitude
     {
         AMPLITUDE_ASSERT(Valid());
 
-        if (_channelLayersId[layer] == kAmInvalidObjectId)
+        const auto it = _layers.find(layer);
+        if (it == _layers.end() || it->second.mixerLayerId == kAmInvalidObjectId)
             return;
 
-        const MixerCommandCallback callback = [&, layer]() -> bool
+        const AmUInt32 mixerLayerId = it->second.mixerLayerId;
+        SoundInstance* soundInstance = it->second.soundInstance;
+
+        const MixerCommandCallback callback = [&, layer, mixerLayerId, soundInstance]() -> bool
         {
-            _mixer->SetPlayState(_channelId, _channelLayersId[layer], ePSF_MIN);
+            _mixer->SetPlayState(_channelId, mixerLayerId, ePSF_MIN);
 
-            _channelLayersId.erase(layer);
-
-            ampooldelete(eMemoryPoolKind_Engine, SoundInstance, _activeSounds[layer]);
-            _activeSounds.erase(layer);
+            ampooldelete(eMemoryPoolKind_Engine, SoundInstance, soundInstance);
+            _layers.erase(layer);
 
             return true;
         };
@@ -190,37 +190,41 @@ namespace SparkyStudios::Audio::Amplitude
     {
         AMPLITUDE_ASSERT(Valid());
 
-        bool playing = true;
-        for (auto&& layer : _channelLayersId)
+        if (_layers.empty())
+            return false;
+
+        for (const auto& [layerIdx, data] : _layers)
         {
-            if (layer.second == 0)
+            if (data.mixerLayerId == 0)
                 continue;
 
-            playing &= Playing(layer.first);
+            if (!Playing(layerIdx))
+                return false;
         }
 
-        return playing;
+        return true;
     }
 
     bool RealChannel::Playing(AmUInt32 layer) const
     {
         AMPLITUDE_ASSERT(Valid());
 
-        const AmUInt32 state = _mixer->GetPlayState(_channelId, _channelLayersId.at(layer));
+        const auto& data = _layers.at(layer);
+        const AmUInt32 state = _mixer->GetPlayState(_channelId, data.mixerLayerId);
         if (state < ePSF_PLAY)
             return false;
 
         if (const auto* collection = _parentChannelState->GetCollection(); collection == nullptr)
         {
-            return !_loop.at(layer) && state == ePSF_PLAY || _loop.at(layer) && state == ePSF_LOOP;
+            return (!data.isLoop && state == ePSF_PLAY) || (data.isLoop && state == ePSF_LOOP);
         }
         else
         {
             const CollectionPlayMode mode = static_cast<const CollectionImpl*>(collection)->GetDefinition()->play_mode();
 
-            return mode == CollectionPlayMode_PlayOne && !_loop.at(layer) ? state == ePSF_PLAY
-                : mode == CollectionPlayMode_PlayOne && _loop.at(layer)   ? state == ePSF_LOOP
-                                                                          : _channelId != kAmInvalidObjectId;
+            return mode == CollectionPlayMode_PlayOne && !data.isLoop ? state == ePSF_PLAY
+                : mode == CollectionPlayMode_PlayOne && data.isLoop   ? state == ePSF_LOOP
+                                                                      : _channelId != kAmInvalidObjectId;
         }
     }
 
@@ -228,34 +232,37 @@ namespace SparkyStudios::Audio::Amplitude
     {
         AMPLITUDE_ASSERT(Valid());
 
-        bool paused = true;
-        for (auto&& layer : _channelLayersId)
+        if (_layers.empty())
+            return false;
+
+        for (const auto& [layerIdx, data] : _layers)
         {
-            if (layer.second == 0)
+            if (data.mixerLayerId == 0)
                 continue;
 
-            paused &= Paused(layer.first);
+            if (!Paused(layerIdx))
+                return false;
         }
 
-        return paused;
+        return true;
     }
 
     bool RealChannel::Paused(AmUInt32 layer) const
     {
         AMPLITUDE_ASSERT(Valid());
-        return _mixer->GetPlayState(_channelId, _channelLayersId.at(layer)) == ePSF_HALT;
+        return _mixer->GetPlayState(_channelId, _layers.at(layer).mixerLayerId) == ePSF_HALT;
     }
 
     void RealChannel::SetGain(const AmReal32 gain)
     {
         AMPLITUDE_ASSERT(Valid());
 
-        for (auto&& layer : _channelLayersId)
+        for (auto&& [layerIdx, data] : _layers)
         {
-            if (layer.second == 0)
+            if (data.mixerLayerId == 0)
                 continue;
 
-            SetGain(gain, layer.first);
+            SetGain(gain, layerIdx);
         }
 
         _defaultGain = gain;
@@ -263,25 +270,27 @@ namespace SparkyStudios::Audio::Amplitude
 
     void RealChannel::SetGain(AmReal32 gain, AmUInt32 layer)
     {
+        auto& data = _layers.at(layer);
         AmReal32 finalGain = gain;
-        if (_activeSounds[layer]->GetSettings().m_kind != SoundKind::Standalone)
-            finalGain = gain * _activeSounds[layer]->GetSettings().m_gain.GetValue();
+        if (data.soundInstance->GetSettings().m_kind != SoundKind::Standalone)
+            finalGain = gain * data.soundInstance->GetSettings().m_gain.GetValue();
 
-        _mixer->SetGain(_channelId, _channelLayersId[layer], finalGain);
-
-        _gain[layer] = gain;
+        _mixer->SetGain(_channelId, data.mixerLayerId, finalGain);
+        data.gain = gain;
     }
 
     AmReal32 RealChannel::GetGain(AmUInt32 layer) const
     {
         AMPLITUDE_ASSERT(Valid());
-        return _gain.contains(layer) ? _gain.at(layer) : _defaultGain;
+        if (const auto it = _layers.find(layer); it != _layers.end())
+            return it->second.gain;
+        return _defaultGain;
     }
 
     bool RealChannel::Halt(AmUInt32 layer)
     {
         AMPLITUDE_ASSERT(Valid());
-        return _mixer->SetPlayState(_channelId, _channelLayersId[layer], ePSF_STOP);
+        return _mixer->SetPlayState(_channelId, _layers.at(layer).mixerLayerId, ePSF_STOP);
     }
 
     bool RealChannel::Halt()
@@ -289,7 +298,7 @@ namespace SparkyStudios::Audio::Amplitude
         AMPLITUDE_ASSERT(Valid());
 
         bool success = true;
-        for (const auto& layer : _channelLayersId | std::views::keys)
+        for (const auto& layer : _layers | std::views::keys)
             success &= Halt(layer);
 
         return success;
@@ -298,7 +307,7 @@ namespace SparkyStudios::Audio::Amplitude
     bool RealChannel::Pause(AmUInt32 layer)
     {
         AMPLITUDE_ASSERT(Valid());
-        return _mixer->SetPlayState(_channelId, _channelLayersId[layer], ePSF_HALT);
+        return _mixer->SetPlayState(_channelId, _layers.at(layer).mixerLayerId, ePSF_HALT);
     }
 
     bool RealChannel::Pause()
@@ -306,7 +315,7 @@ namespace SparkyStudios::Audio::Amplitude
         AMPLITUDE_ASSERT(Valid());
 
         bool success = true;
-        for (const auto& layer : _channelLayersId | std::views::keys)
+        for (const auto& layer : _layers | std::views::keys)
             success &= Pause(layer);
 
         return success;
@@ -315,7 +324,7 @@ namespace SparkyStudios::Audio::Amplitude
     bool RealChannel::Resume(AmUInt32 layer)
     {
         AMPLITUDE_ASSERT(Valid());
-        return _mixer->SetPlayState(_channelId, _channelLayersId[layer], _loop[layer] ? ePSF_LOOP : ePSF_PLAY);
+        return _mixer->SetPlayState(_channelId, _layers.at(layer).mixerLayerId, _layers.at(layer).isLoop ? ePSF_LOOP : ePSF_PLAY);
     }
 
     bool RealChannel::Resume()
@@ -323,7 +332,7 @@ namespace SparkyStudios::Audio::Amplitude
         AMPLITUDE_ASSERT(Valid());
 
         bool success = true;
-        for (const auto& layer : _channelLayersId | std::views::keys)
+        for (const auto& layer : _layers | std::views::keys)
             success &= Resume(layer);
 
         return success;
@@ -333,16 +342,16 @@ namespace SparkyStudios::Audio::Amplitude
     {
         AMPLITUDE_ASSERT(Valid());
 
-        for (auto&& layer : _channelLayersId)
+        for (auto&& [layerIdx, data] : _layers)
         {
-            if (layer.second == 0)
+            if (data.mixerLayerId == 0)
                 continue;
 
             AmReal32 finalPitch = pitch;
-            if (_activeSounds[layer.first]->GetSettings().m_kind != SoundKind::Standalone)
-                finalPitch = pitch * _activeSounds[layer.first]->GetSettings().m_pitch.GetValue();
+            if (data.soundInstance->GetSettings().m_kind != SoundKind::Standalone)
+                finalPitch = pitch * data.soundInstance->GetSettings().m_pitch.GetValue();
 
-            _mixer->SetPitch(_channelId, layer.second, finalPitch);
+            _mixer->SetPitch(_channelId, data.mixerLayerId, finalPitch);
         }
 
         _pitch = pitch;
@@ -352,12 +361,12 @@ namespace SparkyStudios::Audio::Amplitude
     {
         AMPLITUDE_ASSERT(Valid());
 
-        for (auto&& layer : _channelLayersId)
+        for (const auto& [layerIdx, data] : _layers)
         {
-            if (layer.second == 0)
+            if (data.mixerLayerId == 0)
                 continue;
 
-            _mixer->SetPlaySpeed(_channelId, layer.second, speed);
+            _mixer->SetPlaySpeed(_channelId, data.mixerLayerId, speed);
         }
 
         _playSpeed = speed;
@@ -367,12 +376,12 @@ namespace SparkyStudios::Audio::Amplitude
     {
         AMPLITUDE_ASSERT(Valid());
 
-        for (auto&& layer : _channelLayersId)
+        for (const auto& [layerIdx, data] : _layers)
         {
-            if (layer.second == 0)
+            if (data.mixerLayerId == 0)
                 continue;
 
-            _mixer->SetObstruction(_channelId, layer.second, obstruction);
+            _mixer->SetObstruction(_channelId, data.mixerLayerId, obstruction);
         }
     }
 
@@ -380,18 +389,18 @@ namespace SparkyStudios::Audio::Amplitude
     {
         AMPLITUDE_ASSERT(Valid());
 
-        for (auto&& layer : _channelLayersId)
+        for (const auto& [layerIdx, data] : _layers)
         {
-            if (layer.second == 0)
+            if (data.mixerLayerId == 0)
                 continue;
 
-            _mixer->SetOcclusion(_channelId, layer.second, occlusion);
+            _mixer->SetOcclusion(_channelId, data.mixerLayerId, occlusion);
         }
     }
 
     AmUInt32 RealChannel::FindFreeLayer(AmUInt32 layerIndex) const
     {
-        while (_channelLayersId.contains(layerIndex))
+        while (_layers.contains(layerIndex))
             layerIndex++;
 
         return layerIndex;

--- a/src/Mixer/RealChannel.cpp
+++ b/src/Mixer/RealChannel.cpp
@@ -53,7 +53,7 @@ namespace SparkyStudios::Audio::Amplitude
 
     void RealChannel::MarkAsPlayed(const Sound* sound)
     {
-        _playedSounds.push_back(sound->GetId());
+        _playedSounds.insert(sound->GetId());
     }
 
     bool RealChannel::AllSoundsHasPlayed() const
@@ -61,16 +61,11 @@ namespace SparkyStudios::Audio::Amplitude
         if (_parentChannelState->GetCollection() == nullptr)
             return false;
 
-        bool result = true;
         for (auto&& sound : _parentChannelState->GetCollection()->GetSounds())
-        {
-            if (auto foundIt = std::ranges::find(_playedSounds, sound); foundIt != _playedSounds.end())
-                continue;
+            if (!_playedSounds.contains(sound))
+                return false;
 
-            result = false;
-            break;
-        }
-        return result;
+        return true;
     }
 
     void RealChannel::ClearPlayedSounds()

--- a/src/Mixer/RealChannel.cpp
+++ b/src/Mixer/RealChannel.cpp
@@ -162,7 +162,7 @@ namespace SparkyStudios::Audio::Amplitude
         const AmUInt32 mixerLayerId = it->second.mixerLayerId;
         SoundInstance* soundInstance = it->second.soundInstance;
 
-        const MixerCommandCallback callback = [&, layer, mixerLayerId, soundInstance]() -> bool
+        const MixerCommandCallback callback = [this, layer, mixerLayerId, soundInstance]() -> bool
         {
             _mixer->SetPlayState(_channelId, mixerLayerId, ePSF_MIN);
 

--- a/src/Mixer/RealChannel.h
+++ b/src/Mixer/RealChannel.h
@@ -17,6 +17,7 @@
 #ifndef _AM_IMPLEMENTATION_MIXER_REAL_CHANNEL_H
 #define _AM_IMPLEMENTATION_MIXER_REAL_CHANNEL_H
 
+#include <unordered_set>
 #include <vector>
 
 #include <SparkyStudios/Audio/Amplitude/Core/Playback/Channel.h>
@@ -226,7 +227,7 @@ namespace SparkyStudios::Audio::Amplitude
 
         ChannelInternalState* _parentChannelState;
 
-        std::vector<AmSoundID> _playedSounds;
+        std::unordered_set<AmSoundID> _playedSounds;
     };
 } // namespace SparkyStudios::Audio::Amplitude
 

--- a/src/Mixer/RealChannel.h
+++ b/src/Mixer/RealChannel.h
@@ -201,21 +201,28 @@ namespace SparkyStudios::Audio::Amplitude
         void SetOcclusion(AmReal32 occlusion);
 
     private:
+        /**
+         * @brief Holds all per-layer data for a single audio layer on the channel.
+         */
+        struct LayerData
+        {
+            AmUInt32 mixerLayerId = kAmInvalidObjectId; ///< Mixer layer ID returned by AmplimixImpl::Play()
+            bool isStream = false;                      ///< Whether this layer is streaming audio
+            bool isLoop = false;                        ///< Whether this layer should loop
+            AmReal32 gain = 1.0f;                       ///< Per-layer gain value (defaults to unity)
+            SoundInstance* soundInstance = nullptr;      ///< The sound instance playing on this layer
+        };
+
         [[nodiscard]] AmUInt32 FindFreeLayer(AmUInt32 layerIndex = 0) const;
 
         AmChannelID _channelId;
-        std::unordered_map<AmUInt32, AmUInt32> _channelLayersId;
-
-        std::unordered_map<AmUInt32, bool> _stream;
-        std::unordered_map<AmUInt32, bool> _loop;
+        std::unordered_map<AmUInt32, LayerData> _layers;
 
         AmReal32 _defaultGain;
-        std::unordered_map<AmUInt32, AmReal32> _gain;
         AmReal32 _pitch;
         AmReal32 _playSpeed;
 
         AmplimixImpl* _mixer;
-        std::unordered_map<AmUInt32, SoundInstance*> _activeSounds;
 
         ChannelInternalState* _parentChannelState;
 

--- a/src/Mixer/SoundData.cpp
+++ b/src/Mixer/SoundData.cpp
@@ -83,7 +83,7 @@ namespace SparkyStudios::Audio::Amplitude
         }
     }
 
-    SoundChunk* SoundChunkPool::Acquire(AmUInt64 frames, AmUInt16 channels)
+    SoundChunk* SoundChunkPool::Acquire(AmUInt64 frames, AmUInt16 channels, bool clearOnAcquire)
     {
         // Search for reusable chunk with matching or larger capacity
         for (AmSize i = 0; i < allocated; ++i)
@@ -97,7 +97,8 @@ namespace SparkyStudios::Audio::Amplitude
                 if (chunk->frames >= frames && chunkChannels == channels)
                 {
                     chunks[i].inUse = true;
-                    chunk->buffer->Clear();
+                    if (clearOnAcquire)
+                        chunk->buffer->Clear();
                     return chunk;
                 }
             }

--- a/src/Mixer/SoundData.h
+++ b/src/Mixer/SoundData.h
@@ -77,9 +77,10 @@ namespace SparkyStudios::Audio::Amplitude
          *
          * @param[in] frames Number of frames needed.
          * @param[in] channels Number of channels needed.
+         * @param[in] clearOnAcquire If true (default), clears the buffer. Set to false when the caller will immediately overwrite it.
          * @return A SoundChunk pointer (never null).
          */
-        SoundChunk* Acquire(AmUInt64 frames, AmUInt16 channels);
+        SoundChunk* Acquire(AmUInt64 frames, AmUInt16 channels, bool clearOnAcquire = true);
 
         /**
          * @brief Releases a chunk back to the pool.

--- a/src/Sound/Collection.cpp
+++ b/src/Sound/Collection.cpp
@@ -51,7 +51,7 @@ namespace SparkyStudios::Audio::Amplitude
         m_scope = eScope_World;
     }
 
-    Sound* CollectionImpl::SelectFromWorld(const std::vector<AmSoundID>& toSkip) const
+    Sound* CollectionImpl::SelectFromWorld(const std::unordered_set<AmSoundID>& toSkip) const
     {
         const CollectionDefinition* definition = GetDefinition();
         if (_worldScopeScheduler == nullptr || !_worldScopeScheduler->Valid())
@@ -63,7 +63,7 @@ namespace SparkyStudios::Audio::Amplitude
         return _worldScopeScheduler->Select(toSkip);
     }
 
-    Sound* CollectionImpl::SelectFromEntity(const Entity& entity, const std::vector<AmSoundID>& toSkip)
+    Sound* CollectionImpl::SelectFromEntity(const Entity& entity, const std::unordered_set<AmSoundID>& toSkip)
     {
         const CollectionDefinition* definition = GetDefinition();
         if (const auto findIt = _entityScopeSchedulers.find(entity.GetId()); findIt == _entityScopeSchedulers.end())

--- a/src/Sound/Collection.h
+++ b/src/Sound/Collection.h
@@ -128,12 +128,12 @@ namespace SparkyStudios::Audio::Amplitude
         /**
          * @copydoc Collection::SelectFromWorld
          */
-        [[nodiscard]] Sound* SelectFromWorld(const std::vector<AmSoundID>& toSkip) const override;
+        [[nodiscard]] Sound* SelectFromWorld(const std::unordered_set<AmSoundID>& toSkip) const override;
 
         /**
          * @copydoc Collection::SelectFromEntity
          */
-        Sound* SelectFromEntity(const Entity& entity, const std::vector<AmSoundID>& toSkip) override;
+        Sound* SelectFromEntity(const Entity& entity, const std::unordered_set<AmSoundID>& toSkip) override;
 
         /**
          * @copydoc Collection::ResetEntityScopeScheduler

--- a/src/Sound/Scheduler.h
+++ b/src/Sound/Scheduler.h
@@ -17,9 +17,9 @@
 #ifndef _AM_IMPLEMENTATION_SOUND_SCHEDULER_H
 #define _AM_IMPLEMENTATION_SOUND_SCHEDULER_H
 
-#include <SparkyStudios/Audio/Amplitude/Core/Common.h>
+#include <unordered_set>
 
-#include <vector>
+#include <SparkyStudios/Audio/Amplitude/Core/Common.h>
 
 namespace SparkyStudios::Audio::Amplitude
 {
@@ -60,7 +60,7 @@ namespace SparkyStudios::Audio::Amplitude
          *
          * @return The selected sound.
          */
-        virtual Sound* Select(const std::vector<AmSoundID>& toSkip) = 0;
+        virtual Sound* Select(const std::unordered_set<AmSoundID>& toSkip) = 0;
 
         /**
          * @brief Resets the internal state of the scheduler.

--- a/src/Sound/Schedulers/RandomScheduler.cpp
+++ b/src/Sound/Schedulers/RandomScheduler.cpp
@@ -54,7 +54,7 @@ namespace SparkyStudios::Audio::Amplitude
         }
     }
 
-    Sound* RandomScheduler::Select(const std::vector<AmSoundID>& toSkip)
+    Sound* RandomScheduler::Select(const std::unordered_set<AmSoundID>& toSkip)
     {
     Pick:
         AmReal32 selection = static_cast<AmReal32>(std::rand()) / static_cast<AmReal32>(RAND_MAX) * _probabilitiesSum;
@@ -65,7 +65,7 @@ namespace SparkyStudios::Audio::Amplitude
 
             if (selection <= 0)
             {
-                if (auto foundIt = std::ranges::find(toSkip, _sounds[i]->GetId()); foundIt != toSkip.end())
+                if (toSkip.contains(_sounds[i]->GetId()))
                     // Try to pick the next sound, since this one needs to be skipped
                     goto Pick;
 

--- a/src/Sound/Schedulers/RandomScheduler.h
+++ b/src/Sound/Schedulers/RandomScheduler.h
@@ -31,7 +31,7 @@ namespace SparkyStudios::Audio::Amplitude
 
         [[nodiscard]] bool Valid() const override;
         void Init(const CollectionDefinition* definition) override;
-        Sound* Select(const std::vector<AmSoundID>& toSkip) override;
+        Sound* Select(const std::unordered_set<AmSoundID>& toSkip) override;
         void Reset() override;
 
     private:

--- a/src/Sound/Schedulers/SequenceScheduler.cpp
+++ b/src/Sound/Schedulers/SequenceScheduler.cpp
@@ -46,7 +46,7 @@ namespace SparkyStudios::Audio::Amplitude
         }
     }
 
-    Sound* SequenceScheduler::Select(const std::vector<AmSoundID>& toSkip)
+    Sound* SequenceScheduler::Select(const std::unordered_set<AmSoundID>& toSkip)
     {
         const auto count = static_cast<AmInt32>(_sounds.size());
 

--- a/src/Sound/Schedulers/SequenceScheduler.h
+++ b/src/Sound/Schedulers/SequenceScheduler.h
@@ -33,7 +33,7 @@ namespace SparkyStudios::Audio::Amplitude
 
         [[nodiscard]] bool Valid() const override;
         void Init(const CollectionDefinition* definition) override;
-        Sound* Select(const std::vector<AmSoundID>& toSkip) override;
+        Sound* Select(const std::unordered_set<AmSoundID>& toSkip) override;
         void Reset() override;
 
     private:

--- a/src/Sound/Sound.cpp
+++ b/src/Sound/Sound.cpp
@@ -144,6 +144,7 @@ namespace SparkyStudios::Audio::Amplitude
     {
         return AssetImpl::GetId();
     }
+
     const AmString& SoundImpl::GetName() const
     {
         return AssetImpl::GetName();

--- a/tests/core_memory/test_memory_pool_isolation.cpp
+++ b/tests/core_memory/test_memory_pool_isolation.cpp
@@ -26,6 +26,7 @@ namespace SparkyStudios::Audio::Amplitude::Tests
     public:
         void Run() override
         {
+#if !defined(AM_NO_MEMORY_STATS)
             // Initialize memory manager
             MemoryManager::Initialize(nullptr);
 
@@ -167,6 +168,7 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             AM_EXPECT(amMemory->TotalReservedMemorySize(eMemoryPoolKind_Codec) == initialCodec);
 
             MemoryManager::Deinitialize();
+#endif // !defined(AM_NO_MEMORY_STATS)
         }
     };
 

--- a/tests/core_memory/test_scoped_memory_allocation.cpp
+++ b/tests/core_memory/test_scoped_memory_allocation.cpp
@@ -26,6 +26,7 @@ namespace SparkyStudios::Audio::Amplitude::Tests
     public:
         void Run() override
         {
+#if !defined(AM_NO_MEMORY_STATS)
             // Initialize memory manager
             MemoryManager::Initialize(nullptr);
 
@@ -138,6 +139,7 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             } // Memory should be automatically freed even if exceptions occurred
 
             MemoryManager::Deinitialize();
+#endif // !defined(AM_NO_MEMORY_STATS)
         }
     };
 

--- a/tests/fs_mapped_file/test_can_be_opened.cpp
+++ b/tests/fs_mapped_file/test_can_be_opened.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "PlatformTestCase.h"
+#include "SimpleTestCase.h"
+#include "TestRegistry.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, can_be_opened_with_small_file)
+    {
+    public:
+        void Run() override
+        {
+            auto fileSystem = CreatePlatformFileSystem();
+            fileSystem->SetBasePath(GetPlatformAssetsBasePath());
+
+            const auto resolvedPath = fileSystem->ResolvePath(AM_OS_STRING("test_data/diskfile_read_test.txt"));
+
+            MappedFile file;
+            AM_EXPECT(file.Open(resolvedPath) == eErrorCode_Success);
+            AM_EXPECT(file.IsValid());
+            AM_EXPECT(file.Length() == 2);
+            AM_EXPECT(file.GetPtr() != nullptr);
+            AM_EXPECT_NOT(file.IsMapped()); // Below 1 MB threshold, should use heap fallback
+
+            file.Close();
+            AM_EXPECT_NOT(file.IsValid());
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, can_be_opened_with_constructor)
+    {
+    public:
+        void Run() override
+        {
+            auto fileSystem = CreatePlatformFileSystem();
+            fileSystem->SetBasePath(GetPlatformAssetsBasePath());
+
+            const auto resolvedPath = fileSystem->ResolvePath(AM_OS_STRING("test_data/diskfile_read_test.txt"));
+
+            MappedFile file(resolvedPath);
+            AM_EXPECT(file.IsValid());
+            AM_EXPECT(file.Length() == 2);
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, rejects_empty_path)
+    {
+    public:
+        void Run() override
+        {
+            MappedFile file;
+            AM_EXPECT(file.Open("") == eErrorCode_InvalidParameter);
+            AM_EXPECT_NOT(file.IsValid());
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, rejects_nonexistent_file)
+    {
+    public:
+        void Run() override
+        {
+            MappedFile file;
+            AM_EXPECT(file.Open("/nonexistent/path/to/file.bin") == eErrorCode_FileNotFound);
+            AM_EXPECT_NOT(file.IsValid());
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, can_reopen_after_close)
+    {
+    public:
+        void Run() override
+        {
+            auto fileSystem = CreatePlatformFileSystem();
+            fileSystem->SetBasePath(GetPlatformAssetsBasePath());
+
+            const auto resolvedPath = fileSystem->ResolvePath(AM_OS_STRING("test_data/diskfile_read_test.txt"));
+
+            MappedFile file;
+            AM_EXPECT(file.Open(resolvedPath) == eErrorCode_Success);
+            AM_EXPECT(file.IsValid());
+            AM_EXPECT(file.Length() == 2);
+
+            file.Close();
+            AM_EXPECT_NOT(file.IsValid());
+
+            // Reopen the same file
+            AM_EXPECT(file.Open(resolvedPath) == eErrorCode_Success);
+            AM_EXPECT(file.IsValid());
+            AM_EXPECT(file.Length() == 2);
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, open_cleans_previous_state)
+    {
+    public:
+        void Run() override
+        {
+            auto fileSystem = CreatePlatformFileSystem();
+            fileSystem->SetBasePath(GetPlatformAssetsBasePath());
+
+            const auto resolvedPath = fileSystem->ResolvePath(AM_OS_STRING("test_data/diskfile_read_test.txt"));
+
+            MappedFile file;
+            AM_EXPECT(file.Open(resolvedPath) == eErrorCode_Success);
+
+            // Advance the read cursor
+            file.Seek(1, eFileSeekOrigin_Start);
+            AM_EXPECT(file.Position() == 1);
+
+            // Opening again should reset state
+            AM_EXPECT(file.Open(resolvedPath) == eErrorCode_Success);
+            AM_EXPECT(file.Position() == 0);
+        }
+    };
+
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, can_be_opened_with_small_file);
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, can_be_opened_with_constructor);
+    AM_REGISTER_TEST(fs_mapped_file, rejects_empty_path);
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, rejects_nonexistent_file);
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, can_reopen_after_close);
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, open_cleans_previous_state);
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/fs_mapped_file/test_can_be_read.cpp
+++ b/tests/fs_mapped_file/test_can_be_read.cpp
@@ -1,0 +1,163 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "PlatformTestCase.h"
+#include "SimpleTestCase.h"
+#include "TestRegistry.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, can_read_data)
+    {
+    public:
+        void Run() override
+        {
+            auto fileSystem = CreatePlatformFileSystem();
+            fileSystem->SetBasePath(GetPlatformAssetsBasePath());
+
+            const auto resolvedPath = fileSystem->ResolvePath(AM_OS_STRING("test_data/diskfile_read_test.txt"));
+
+            MappedFile file;
+            AM_EXPECT(file.Open(resolvedPath) == eErrorCode_Success);
+
+            char buf[2] = {};
+            AM_EXPECT(file.Read(reinterpret_cast<AmUInt8Buffer>(buf), 2) == 2);
+            AM_EXPECT(buf[0] == 'O');
+            AM_EXPECT(buf[1] == 'K');
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, can_read_with_seek)
+    {
+    public:
+        void Run() override
+        {
+            auto fileSystem = CreatePlatformFileSystem();
+            fileSystem->SetBasePath(GetPlatformAssetsBasePath());
+
+            const auto resolvedPath = fileSystem->ResolvePath(AM_OS_STRING("test_data/diskfile_read_test.txt"));
+
+            MappedFile file;
+            AM_EXPECT(file.Open(resolvedPath) == eErrorCode_Success);
+
+            // Seek from start
+            file.Seek(1, eFileSeekOrigin_Start);
+            AM_EXPECT(file.Position() == 1);
+            AM_EXPECT(file.Read8() == 'K');
+
+            // Seek from end
+            file.Seek(-2, eFileSeekOrigin_End);
+            AM_EXPECT(file.Position() == 0);
+            AM_EXPECT(file.Read8() == 'O');
+
+            // Seek from current (back one byte)
+            file.Seek(-1, eFileSeekOrigin_Current);
+            AM_EXPECT(file.Position() == 0);
+            AM_EXPECT(file.Read8() == 'O');
+
+            // Seek past end clamps
+            file.Seek(1234, eFileSeekOrigin_Start);
+            AM_EXPECT(file.Position() == 1); // Clamped to m_dataSize - 1
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, reports_eof)
+    {
+    public:
+        void Run() override
+        {
+            auto fileSystem = CreatePlatformFileSystem();
+            fileSystem->SetBasePath(GetPlatformAssetsBasePath());
+
+            const auto resolvedPath = fileSystem->ResolvePath(AM_OS_STRING("test_data/diskfile_read_test.txt"));
+
+            MappedFile file;
+            AM_EXPECT(file.Open(resolvedPath) == eErrorCode_Success);
+
+            AM_EXPECT_NOT(file.Eof());
+
+            // Read all data
+            char buf[2] = {};
+            file.Read(reinterpret_cast<AmUInt8Buffer>(buf), 2);
+            AM_EXPECT(file.Position() == file.Length());
+            AM_EXPECT(file.Eof());
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, read_clamps_at_eof)
+    {
+    public:
+        void Run() override
+        {
+            auto fileSystem = CreatePlatformFileSystem();
+            fileSystem->SetBasePath(GetPlatformAssetsBasePath());
+
+            const auto resolvedPath = fileSystem->ResolvePath(AM_OS_STRING("test_data/diskfile_read_test.txt"));
+
+            MappedFile file;
+            AM_EXPECT(file.Open(resolvedPath) == eErrorCode_Success);
+
+            // Request more bytes than available
+            char buf[16] = {};
+            const AmSize bytesRead = file.Read(reinterpret_cast<AmUInt8Buffer>(buf), 16);
+            AM_EXPECT(bytesRead == 2);
+            AM_EXPECT(buf[0] == 'O');
+            AM_EXPECT(buf[1] == 'K');
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, getptr_returns_buffer)
+    {
+    public:
+        void Run() override
+        {
+            auto fileSystem = CreatePlatformFileSystem();
+            fileSystem->SetBasePath(GetPlatformAssetsBasePath());
+
+            const auto resolvedPath = fileSystem->ResolvePath(AM_OS_STRING("test_data/diskfile_read_test.txt"));
+
+            MappedFile file;
+            AM_EXPECT(file.Open(resolvedPath) == eErrorCode_Success);
+
+            auto* ptr = static_cast<const AmUInt8*>(file.GetPtr());
+            AM_EXPECT(ptr != nullptr);
+            AM_EXPECT(ptr[0] == 'O');
+            AM_EXPECT(ptr[1] == 'K');
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, read_on_invalid_file_returns_zero)
+    {
+    public:
+        void Run() override
+        {
+            MappedFile file;
+            AM_EXPECT_NOT(file.IsValid());
+
+            char buf[4] = {};
+            AM_EXPECT(file.Read(reinterpret_cast<AmUInt8Buffer>(buf), 4) == 0);
+        }
+    };
+
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, can_read_data);
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, can_read_with_seek);
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, reports_eof);
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, read_clamps_at_eof);
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, getptr_returns_buffer);
+    AM_REGISTER_TEST(fs_mapped_file, read_on_invalid_file_returns_zero);
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/fs_mapped_file/test_can_be_read.cpp
+++ b/tests/fs_mapped_file/test_can_be_read.cpp
@@ -72,7 +72,7 @@ namespace SparkyStudios::Audio::Amplitude::Tests
 
             // Seek past end clamps
             file.Seek(1234, eFileSeekOrigin_Start);
-            AM_EXPECT(file.Position() == 1); // Clamped to m_dataSize - 1
+            AM_EXPECT(file.Position() == 2);
         }
     };
 

--- a/tests/fs_mapped_file/test_can_map_large_file.cpp
+++ b/tests/fs_mapped_file/test_can_map_large_file.cpp
@@ -32,7 +32,13 @@ namespace SparkyStudios::Audio::Amplitude::Tests
         {
             auto path = std::filesystem::temp_directory_path() / "am_mapped_file_test.bin";
 
-            FILE* fp = fopen(path.c_str(), "wb");
+            AmFileHandle fp;
+            #if AM_PLATFORM_WIN
+                    _wfopen_s(&fp, path.c_str(), AM_OS_STRING("wb"));
+            #else
+                    fp = fopen(path.c_str(), op.c_str());
+            #endif
+
             if (fp == nullptr)
                 return {};
 
@@ -142,7 +148,12 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             constexpr AmSize kFileSize = 2 * 1024 * 1024; // 2 MB
             auto path = std::filesystem::temp_directory_path() / "am_mapped_file_seq_test.bin";
 
-            FILE* fp = fopen(path.c_str(), "wb");
+            AmFileHandle fp;
+            #if AM_PLATFORM_WIN
+                    _wfopen_s(&fp, path.c_str(), AM_OS_STRING("wb"));
+            #else
+                    fp = fopen(path.c_str(), op.c_str());
+            #endif
             AM_EXPECT(fp != nullptr);
 
             constexpr AmSize kChunkSize = 4096;

--- a/tests/fs_mapped_file/test_can_map_large_file.cpp
+++ b/tests/fs_mapped_file/test_can_map_large_file.cpp
@@ -1,0 +1,248 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include <cstdio>
+#include <filesystem>
+
+#include "SimpleTestCase.h"
+#include "TestRegistry.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    namespace
+    {
+        // Creates a temporary file filled with a repeating byte pattern.
+        // Returns the path to the created file.
+        std::filesystem::path CreateTempFile(AmSize size, AmUInt8 fillByte)
+        {
+            auto path = std::filesystem::temp_directory_path() / "am_mapped_file_test.bin";
+
+            FILE* fp = fopen(path.c_str(), "wb");
+            if (fp == nullptr)
+                return {};
+
+            constexpr AmSize kChunkSize = 4096;
+            AmUInt8 chunk[kChunkSize];
+            std::memset(chunk, fillByte, kChunkSize);
+
+            AmSize remaining = size;
+            while (remaining > 0)
+            {
+                const AmSize toWrite = remaining < kChunkSize ? remaining : kChunkSize;
+                fwrite(chunk, 1, toWrite, fp);
+                remaining -= toWrite;
+            }
+
+            fclose(fp);
+            return path;
+        }
+
+        void RemoveTempFile(const std::filesystem::path& path)
+        {
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+        }
+    } // anonymous namespace
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, maps_large_file_on_desktop)
+    {
+    public:
+        void Run() override
+        {
+            constexpr AmSize kFileSize = 2 * 1024 * 1024; // 2 MB
+            constexpr AmUInt8 kFillByte = 0xAB;
+
+            const auto tempPath = CreateTempFile(kFileSize, kFillByte);
+            AM_EXPECT_NOT(tempPath.empty());
+
+            MappedFile file;
+            AM_EXPECT(file.Open(tempPath) == eErrorCode_Success);
+            AM_EXPECT(file.IsValid());
+            AM_EXPECT(file.Length() == kFileSize);
+
+#if AM_PLATFORM_WIN || AM_PLATFORM_LINUX || AM_PLATFORM_APPLE
+            AM_EXPECT(file.IsMapped());
+#else
+            AM_EXPECT_NOT(file.IsMapped()); // Fallback on unsupported platforms
+#endif
+
+            AM_EXPECT(file.GetPtr() != nullptr);
+
+            // Verify content via GetPtr()
+            auto* ptr = static_cast<const AmUInt8*>(file.GetPtr());
+            AM_EXPECT(ptr[0] == kFillByte);
+            AM_EXPECT(ptr[kFileSize / 2] == kFillByte);
+            AM_EXPECT(ptr[kFileSize - 1] == kFillByte);
+
+            // Verify content via Read()
+            file.Seek(0, eFileSeekOrigin_Start);
+            AmUInt8 buf[4] = {};
+            AM_EXPECT(file.Read(buf, 4) == 4);
+            AM_EXPECT(buf[0] == kFillByte);
+            AM_EXPECT(buf[1] == kFillByte);
+            AM_EXPECT(buf[2] == kFillByte);
+            AM_EXPECT(buf[3] == kFillByte);
+
+            file.Close();
+            AM_EXPECT_NOT(file.IsValid());
+            AM_EXPECT_NOT(file.IsMapped());
+
+            RemoveTempFile(tempPath);
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, small_file_uses_heap_fallback)
+    {
+    public:
+        void Run() override
+        {
+            constexpr AmSize kFileSize = 512 * 1024; // 512 KB (below 1 MB threshold)
+            constexpr AmUInt8 kFillByte = 0xCD;
+
+            const auto tempPath = CreateTempFile(kFileSize, kFillByte);
+            AM_EXPECT_NOT(tempPath.empty());
+
+            MappedFile file;
+            AM_EXPECT(file.Open(tempPath) == eErrorCode_Success);
+            AM_EXPECT(file.IsValid());
+            AM_EXPECT(file.Length() == kFileSize);
+            AM_EXPECT_NOT(file.IsMapped()); // Below threshold, always heap
+
+            // Verify content
+            auto* ptr = static_cast<const AmUInt8*>(file.GetPtr());
+            AM_EXPECT(ptr[0] == kFillByte);
+            AM_EXPECT(ptr[kFileSize - 1] == kFillByte);
+
+            file.Close();
+            RemoveTempFile(tempPath);
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, seek_and_read_large_file)
+    {
+    public:
+        void Run() override
+        {
+            // Create a file with sequential byte values (modulo 256)
+            constexpr AmSize kFileSize = 2 * 1024 * 1024; // 2 MB
+            auto path = std::filesystem::temp_directory_path() / "am_mapped_file_seq_test.bin";
+
+            FILE* fp = fopen(path.c_str(), "wb");
+            AM_EXPECT(fp != nullptr);
+
+            constexpr AmSize kChunkSize = 4096;
+            AmUInt8 chunk[kChunkSize];
+            AmSize written = 0;
+            while (written < kFileSize)
+            {
+                const AmSize toWrite = (kFileSize - written) < kChunkSize ? (kFileSize - written) : kChunkSize;
+                for (AmSize i = 0; i < toWrite; ++i)
+                    chunk[i] = static_cast<AmUInt8>((written + i) & 0xFF);
+                fwrite(chunk, 1, toWrite, fp);
+                written += toWrite;
+            }
+            fclose(fp);
+
+            MappedFile file;
+            AM_EXPECT(file.Open(path) == eErrorCode_Success);
+
+            // Read from start
+            file.Seek(0, eFileSeekOrigin_Start);
+            AM_EXPECT(file.Read8() == 0x00);
+            AM_EXPECT(file.Read8() == 0x01);
+            AM_EXPECT(file.Read8() == 0x02);
+
+            // Seek to a known offset and verify
+            file.Seek(256, eFileSeekOrigin_Start);
+            AM_EXPECT(file.Position() == 256);
+            AM_EXPECT(file.Read8() == 0x00); // 256 & 0xFF == 0
+
+            // Seek from end
+            file.Seek(-1, eFileSeekOrigin_End);
+            AM_EXPECT(file.Position() == kFileSize - 1);
+            AM_EXPECT(file.Read8() == static_cast<AmUInt8>((kFileSize - 1) & 0xFF));
+
+            file.Close();
+
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, write_returns_zero_on_mapped)
+    {
+    public:
+        void Run() override
+        {
+            constexpr AmSize kFileSize = 2 * 1024 * 1024; // 2 MB
+            constexpr AmUInt8 kFillByte = 0x42;
+
+            const auto tempPath = CreateTempFile(kFileSize, kFillByte);
+            AM_EXPECT_NOT(tempPath.empty());
+
+            MappedFile file;
+            AM_EXPECT(file.Open(tempPath) == eErrorCode_Success);
+
+            const AmUInt8 data[] = { 0xFF, 0xFF };
+            AM_EXPECT(file.Write(data, 2) == 0);
+
+            // Content unchanged
+            auto* ptr = static_cast<const AmUInt8*>(file.GetPtr());
+            AM_EXPECT(ptr[0] == kFillByte);
+
+            file.Close();
+            RemoveTempFile(tempPath);
+        }
+    };
+
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, can_reopen_large_file)
+    {
+    public:
+        void Run() override
+        {
+            constexpr AmSize kFileSize = 2 * 1024 * 1024;
+            constexpr AmUInt8 kFillByte = 0xEF;
+
+            const auto tempPath = CreateTempFile(kFileSize, kFillByte);
+            AM_EXPECT_NOT(tempPath.empty());
+
+            MappedFile file;
+
+            // First open
+            AM_EXPECT(file.Open(tempPath) == eErrorCode_Success);
+            AM_EXPECT(file.IsValid());
+            file.Seek(1024, eFileSeekOrigin_Start);
+            AM_EXPECT(file.Position() == 1024);
+
+            // Second open should reset state
+            AM_EXPECT(file.Open(tempPath) == eErrorCode_Success);
+            AM_EXPECT(file.IsValid());
+            AM_EXPECT(file.Position() == 0);
+            AM_EXPECT(file.Length() == kFileSize);
+
+            file.Close();
+            RemoveTempFile(tempPath);
+        }
+    };
+
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, maps_large_file_on_desktop);
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, small_file_uses_heap_fallback);
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, seek_and_read_large_file);
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, write_returns_zero_on_mapped);
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, can_reopen_large_file);
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/fs_mapped_file/test_can_map_large_file.cpp
+++ b/tests/fs_mapped_file/test_can_map_large_file.cpp
@@ -32,11 +32,11 @@ namespace SparkyStudios::Audio::Amplitude::Tests
         {
             auto path = std::filesystem::temp_directory_path() / "am_mapped_file_test.bin";
 
-            AmFileHandle fp;
+            AmFileHandle fp = nullptr;
             #if AM_PLATFORM_WIN
                     _wfopen_s(&fp, path.c_str(), AM_OS_STRING("wb"));
             #else
-                    fp = fopen(path.c_str(), op.c_str());
+                    fp = fopen(path.c_str(), AM_OS_STRING("wb"));
             #endif
 
             if (fp == nullptr)
@@ -148,11 +148,11 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             constexpr AmSize kFileSize = 2 * 1024 * 1024; // 2 MB
             auto path = std::filesystem::temp_directory_path() / "am_mapped_file_seq_test.bin";
 
-            AmFileHandle fp;
+            AmFileHandle fp = nullptr;
             #if AM_PLATFORM_WIN
                     _wfopen_s(&fp, path.c_str(), AM_OS_STRING("wb"));
             #else
-                    fp = fopen(path.c_str(), op.c_str());
+                    fp = fopen(path.c_str(), AM_OS_STRING("wb"));
             #endif
             AM_EXPECT(fp != nullptr);
 

--- a/tests/fs_mapped_file/test_write_is_readonly.cpp
+++ b/tests/fs_mapped_file/test_write_is_readonly.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "PlatformTestCase.h"
+#include "SimpleTestCase.h"
+#include "TestRegistry.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    AM_TEST_CASE(SimpleTestCase, fs_mapped_file, write_returns_zero)
+    {
+    public:
+        void Run() override
+        {
+            auto fileSystem = CreatePlatformFileSystem();
+            fileSystem->SetBasePath(GetPlatformAssetsBasePath());
+
+            const auto resolvedPath = fileSystem->ResolvePath(AM_OS_STRING("test_data/diskfile_read_test.txt"));
+
+            MappedFile file;
+            AM_EXPECT(file.Open(resolvedPath) == eErrorCode_Success);
+
+            const AmUInt8 data[] = { 0xAB, 0xCD };
+            AM_EXPECT(file.Write(data, 2) == 0);
+
+            // Data should be unchanged
+            auto* ptr = static_cast<const AmUInt8*>(file.GetPtr());
+            AM_EXPECT(ptr[0] == 'O');
+            AM_EXPECT(ptr[1] == 'K');
+        }
+    };
+
+    AM_REGISTER_TEST_DESKTOP_ONLY(fs_mapped_file, write_returns_zero);
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/fs_memory_file/test_can_be_read.cpp
+++ b/tests/fs_memory_file/test_can_be_read.cpp
@@ -48,8 +48,8 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             AM_EXPECT(file.Position() == 0);
             AM_EXPECT(file.Read8() == 'O');
             file.Seek(1234, eFileSeekOrigin_Start);
-            AM_EXPECT(file.Position() == 1);
-            AM_EXPECT(file.Read8() == 'K');
+            AM_EXPECT(file.Position() == 2);
+            AM_EXPECT(file.Read8() == 0);
 
             file.Seek(0, eFileSeekOrigin_Start);
             auto* content = static_cast<AmUInt8Buffer>(ammalloc(2));


### PR DESCRIPTION
This PR introduces significant performance improvements and critical thread safety fixes to the Amplitude Audio SDK:

- **Performance Optimizations:**
  - Reduced heap allocations in package decompression and pipeline processing
  - Migrated from `vector` to `unordered_set` to reduce lookup complexity
  - Consolidated per-layer state into single struct for better cache locality
  - Optimized hash lookups during pipeline setup and processing
  - Enhanced Amplimix performance with refactored processing logic

- **New Features:**
  - `MappedFile` implementation
  - MPSC and SPSC queue implementations for lock-free inter-thread communication
  - Process channel events in game thread for better performance

- **Bug Fixes:**
  - Fixed thread safety issues: atomic `_activeLayersCount`, inline push command data race
  - Fixed memory leaks in Amplimix
  - Fixed possible UB in offset overflow/underflow
  - Fixed runtime issues on Windows platform