### PR TITLE
Add channel seek and playback position support

### DIFF
--- a/include/SparkyStudios/Audio/Amplitude/Core/Playback/Channel.h
+++ b/include/SparkyStudios/Audio/Amplitude/Core/Playback/Channel.h
@@ -215,8 +215,8 @@ namespace SparkyStudios::Audio::Amplitude
         /**
          * @brief Gets the location of this channel in the game environment.
          *
-         * If the audio on this channel
-         * doesn't support positional data, this method will return an invalid location.
+         * If the audio on this channel doesn't support positional data, this method will
+         * return an invalid location.
          *
          * @return The location of this channel.
          */

--- a/include/SparkyStudios/Audio/Amplitude/Core/Playback/Channel.h
+++ b/include/SparkyStudios/Audio/Amplitude/Core/Playback/Channel.h
@@ -196,15 +196,20 @@ namespace SparkyStudios::Audio::Amplitude
          */
         void Resume(AmTime duration = kMinFadeDuration) const;
 
-        /// @brief Seeks this channel to the given playback position.
-        ///
-        /// @param[in] position The playback position in milliseconds.
-        /// @return @c true if the channel was seeked, @c false otherwise.
-        bool Seek(AmTime position) const;
+        /**
+         * @brief Sets this channel's playback position.
+         *
+         * @param[in] position The playback position in milliseconds.
+         *
+         * @return @c true if the playback position was set, @c false otherwise.
+         */
+        bool SetPlaybackPosition(AmTime position) const;
 
-        /// @brief Gets this channel's current playback position.
-        ///
-        /// @return The current playback position in milliseconds.
+        /**
+         * @brief Gets this channel's current playback position.
+         *
+         * @return The current playback position in milliseconds.
+         */
         [[nodiscard]] AmTime GetPlaybackPosition() const;
 
         /**

--- a/include/SparkyStudios/Audio/Amplitude/Core/Playback/Channel.h
+++ b/include/SparkyStudios/Audio/Amplitude/Core/Playback/Channel.h
@@ -196,11 +196,22 @@ namespace SparkyStudios::Audio::Amplitude
          */
         void Resume(AmTime duration = kMinFadeDuration) const;
 
+        /// @brief Seeks this channel to the given playback position.
+        ///
+        /// @param[in] position The playback position in milliseconds.
+        /// @return @c true if the channel was seeked, @c false otherwise.
+        bool Seek(AmTime position) const;
+
+        /// @brief Gets this channel's current playback position.
+        ///
+        /// @return The current playback position in milliseconds.
+        [[nodiscard]] AmTime GetPlaybackPosition() const;
+
         /**
          * @brief Gets the location of this channel in the game environment.
          *
-         * If the audio on this channel doesn't support positional data, this method will
-         * return an invalid location.
+         * If the audio on this channel
+         * doesn't support positional data, this method will return an invalid location.
          *
          * @return The location of this channel.
          */

--- a/src/Core/Playback/Channel.cpp
+++ b/src/Core/Playback/Channel.cpp
@@ -116,13 +116,13 @@ namespace SparkyStudios::Audio::Amplitude
             _state->FadeIn(duration);
     }
 
-    bool Channel::Seek(AmTime position) const
+    bool Channel::SetPlaybackPosition(AmTime position) const
     {
         AMPLITUDE_ASSERT(Valid());
         if (!IsValidStateId())
             return false;
 
-        return _state->Seek(position);
+        return _state->SetPlaybackPosition(position);
     }
 
     AmTime Channel::GetPlaybackPosition() const

--- a/src/Core/Playback/Channel.cpp
+++ b/src/Core/Playback/Channel.cpp
@@ -116,6 +116,24 @@ namespace SparkyStudios::Audio::Amplitude
             _state->FadeIn(duration);
     }
 
+    bool Channel::Seek(AmTime position) const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        if (!IsValidStateId())
+            return false;
+
+        return _state->Seek(position);
+    }
+
+    AmTime Channel::GetPlaybackPosition() const
+    {
+        AMPLITUDE_ASSERT(Valid());
+        if (IsValidStateId())
+            return _state->GetPlaybackPosition();
+
+        return 0.0;
+    }
+
     const AmVector3& Channel::GetLocation() const
     {
         AMPLITUDE_ASSERT(Valid());

--- a/src/Core/Playback/ChannelInternalState.cpp
+++ b/src/Core/Playback/ChannelInternalState.cpp
@@ -219,7 +219,7 @@ namespace SparkyStudios::Audio::Amplitude
             _channelState = eChannelPlaybackState_Playing;
     }
 
-    bool ChannelInternalState::Seek(AmTime position)
+    bool ChannelInternalState::SetPlaybackPosition(AmTime position)
     {
         if (!Valid())
             return false;

--- a/src/Core/Playback/ChannelInternalState.cpp
+++ b/src/Core/Playback/ChannelInternalState.cpp
@@ -219,6 +219,38 @@ namespace SparkyStudios::Audio::Amplitude
             _channelState = eChannelPlaybackState_Playing;
     }
 
+    bool ChannelInternalState::Seek(AmTime position)
+    {
+        if (!Valid())
+            return false;
+
+        if (_instancingEnabled && _instancingMode == eChannelInstanceMode_Separate)
+        {
+            amLogWarning(
+                "Cannot seek channel " AM_ID_CHAR_FMT ". Separate instanced rendering uses divergent playback cursors.", _channelStateId);
+            return false;
+        }
+
+        return _realChannel.Seek(position);
+    }
+
+    AmTime ChannelInternalState::GetPlaybackPosition() const
+    {
+        if (!Valid())
+            return 0.0;
+
+        if (_instancingEnabled && _instancingMode == eChannelInstanceMode_Separate)
+        {
+            amLogWarning(
+                "Cannot query playback position for channel " AM_ID_CHAR_FMT
+                ". Separate instanced rendering uses divergent playback cursors.",
+                _channelStateId);
+            return 0.0;
+        }
+
+        return _realChannel.GetPlaybackPosition();
+    }
+
     void ChannelInternalState::FadeIn(AmTime duration)
     {
         if (Playing() || !Valid() || _channelState == eChannelPlaybackState_FadingIn)

--- a/src/Core/Playback/ChannelInternalState.h
+++ b/src/Core/Playback/ChannelInternalState.h
@@ -231,6 +231,12 @@ namespace SparkyStudios::Audio::Amplitude
         // Resumes this channel if it is paused.
         void Resume();
 
+        // Seeks this channel to the specified position, in milliseconds.
+        bool Seek(AmTime position);
+
+        // Gets this channel's current playback position, in milliseconds.
+        [[nodiscard]] AmTime GetPlaybackPosition() const;
+
         // Fade in over the specified number of milliseconds.
         void FadeIn(AmTime duration);
 

--- a/src/Core/Playback/ChannelInternalState.h
+++ b/src/Core/Playback/ChannelInternalState.h
@@ -231,8 +231,8 @@ namespace SparkyStudios::Audio::Amplitude
         // Resumes this channel if it is paused.
         void Resume();
 
-        // Seeks this channel to the specified position, in milliseconds.
-        bool Seek(AmTime position);
+        // Sets this channel's playback position, in milliseconds.
+        bool SetPlaybackPosition(AmTime position);
 
         // Gets this channel's current playback position, in milliseconds.
         [[nodiscard]] AmTime GetPlaybackPosition() const;

--- a/src/DSP/AudioConverter.cpp
+++ b/src/DSP/AudioConverter.cpp
@@ -134,7 +134,6 @@ namespace SparkyStudios::Audio::Amplitude
 
     void AudioConverter::Reset()
     {
-        _channelConversionMode = kChannelConversionModeDisabled;
         _resampler->Reset();
     }
 

--- a/src/Mixer/Amplimix.cpp
+++ b/src/Mixer/Amplimix.cpp
@@ -503,9 +503,6 @@ namespace SparkyStudios::Audio::Amplitude
             AMPLIMIX_STORE(&lay->baseSampleRateRatio, baseRatio);
             // store the initial value for sample rate ratio
             AMPLIMIX_STORE(&lay->sampleRateRatio, baseRatio * pitch * speed);
-            // clear stale reset requests from earlier plays on this layer
-            AMPLIMIX_STORE(&lay->resetRequested, false);
-
             // Initialize the converter
             lay->dataConverter = ampoolnew(eMemoryPoolKind_Amplimix, AudioConverter);
 
@@ -603,8 +600,6 @@ namespace SparkyStudios::Audio::Amplitude
         AMPLIMIX_STORE(&lay->cursor, AM_CLAMP(cursor, lay->start, lay->end));
 #endif // AM_SIMD_INTRINSICS
 
-        AMPLIMIX_STORE(&lay->resetRequested, true);
-
         return true;
     }
 
@@ -616,6 +611,21 @@ namespace SparkyStudios::Audio::Amplitude
             return false;
 
         cursor = AMPLIMIX_LOAD(&lay->cursor);
+
+        return true;
+    }
+
+    bool AmplimixImpl::ResetLayerState(AmUInt32 id, AmUInt32 layer)
+    {
+        auto* lay = GetLayer(layer);
+
+        if (AMPLIMIX_LOAD(&lay->flag) <= ePSF_STOP || id != lay->id)
+            return false;
+
+        if (lay->dataConverter != nullptr)
+            lay->dataConverter->Reset();
+
+        lay->ResetPipeline();
 
         return true;
     }
@@ -819,13 +829,6 @@ namespace SparkyStudios::Audio::Amplitude
             amLogWarning("No active pipeline is set, this means no sound will be rendered. You should configure the Amplimix "
                          "pipeline in your engine configuration file.");
             return;
-        }
-
-        if (AMPLIMIX_LOAD(&layer->resetRequested))
-        {
-            AMPLIMIX_STORE(&layer->resetRequested, false);
-            layer->dataConverter->Reset();
-            layer->pipeline->Reset();
         }
 
         // Check for separate mode instancing - process each instance independently

--- a/src/Mixer/Amplimix.cpp
+++ b/src/Mixer/Amplimix.cpp
@@ -503,6 +503,7 @@ namespace SparkyStudios::Audio::Amplitude
             AMPLIMIX_STORE(&lay->baseSampleRateRatio, baseRatio);
             // store the initial value for sample rate ratio
             AMPLIMIX_STORE(&lay->sampleRateRatio, baseRatio * pitch * speed);
+
             // Initialize the converter
             lay->dataConverter = ampoolnew(eMemoryPoolKind_Amplimix, AudioConverter);
 

--- a/src/Mixer/Amplimix.cpp
+++ b/src/Mixer/Amplimix.cpp
@@ -503,6 +503,8 @@ namespace SparkyStudios::Audio::Amplitude
             AMPLIMIX_STORE(&lay->baseSampleRateRatio, baseRatio);
             // store the initial value for sample rate ratio
             AMPLIMIX_STORE(&lay->sampleRateRatio, baseRatio * pitch * speed);
+            // clear stale reset requests from earlier plays on this layer
+            AMPLIMIX_STORE(&lay->resetRequested, false);
 
             // Initialize the converter
             lay->dataConverter = ampoolnew(eMemoryPoolKind_Amplimix, AudioConverter);
@@ -600,6 +602,20 @@ namespace SparkyStudios::Audio::Amplitude
         // clamp cursor and store it
         AMPLIMIX_STORE(&lay->cursor, AM_CLAMP(cursor, lay->start, lay->end));
 #endif // AM_SIMD_INTRINSICS
+
+        AMPLIMIX_STORE(&lay->resetRequested, true);
+
+        return true;
+    }
+
+    bool AmplimixImpl::GetCursor(AmUInt32 id, AmUInt32 layer, AmUInt64& cursor)
+    {
+        auto* lay = GetLayer(layer);
+
+        if (AMPLIMIX_LOAD(&lay->flag) <= ePSF_STOP || id != lay->id)
+            return false;
+
+        cursor = AMPLIMIX_LOAD(&lay->cursor);
 
         return true;
     }
@@ -803,6 +819,13 @@ namespace SparkyStudios::Audio::Amplitude
             amLogWarning("No active pipeline is set, this means no sound will be rendered. You should configure the Amplimix "
                          "pipeline in your engine configuration file.");
             return;
+        }
+
+        if (AMPLIMIX_LOAD(&layer->resetRequested))
+        {
+            AMPLIMIX_STORE(&layer->resetRequested, false);
+            layer->dataConverter->Reset();
+            layer->pipeline->Reset();
         }
 
         // Check for separate mode instancing - process each instance independently

--- a/src/Mixer/Amplimix.h
+++ b/src/Mixer/Amplimix.h
@@ -77,7 +77,6 @@ namespace SparkyStudios::Audio::Amplitude
         std::atomic<AmReal32> targetPlaySpeed; // computed (real) sound playback speed
         std::atomic<AmReal32> sampleRateRatio; // sample rate ratio
         std::atomic<AmReal32> baseSampleRateRatio; // base sample rate ratio
-        std::atomic_bool resetRequested; // converter and pipeline reset request
 
         AudioConverter* dataConverter = nullptr; // miniaudio resampler & channel converter
         std::shared_ptr<PipelineInstance> pipeline = nullptr; // pipeline for this layer
@@ -245,6 +244,8 @@ namespace SparkyStudios::Audio::Amplitude
         bool SetCursor(AmUInt32 id, AmUInt32 layer, AmUInt64 cursor);
 
         bool GetCursor(AmUInt32 id, AmUInt32 layer, AmUInt64& cursor);
+
+        bool ResetLayerState(AmUInt32 id, AmUInt32 layer);
 
         bool SetPlayState(AmUInt32 id, AmUInt32 layer, PlayStateFlag flag);
 

--- a/src/Mixer/Amplimix.h
+++ b/src/Mixer/Amplimix.h
@@ -77,6 +77,7 @@ namespace SparkyStudios::Audio::Amplitude
         std::atomic<AmReal32> targetPlaySpeed; // computed (real) sound playback speed
         std::atomic<AmReal32> sampleRateRatio; // sample rate ratio
         std::atomic<AmReal32> baseSampleRateRatio; // base sample rate ratio
+        std::atomic_bool resetRequested; // converter and pipeline reset request
 
         AudioConverter* dataConverter = nullptr; // miniaudio resampler & channel converter
         std::shared_ptr<PipelineInstance> pipeline = nullptr; // pipeline for this layer
@@ -242,6 +243,8 @@ namespace SparkyStudios::Audio::Amplitude
         bool SetPitch(AmUInt32 id, AmUInt32 layer, AmReal32 pitch);
 
         bool SetCursor(AmUInt32 id, AmUInt32 layer, AmUInt64 cursor);
+
+        bool GetCursor(AmUInt32 id, AmUInt32 layer, AmUInt64& cursor);
 
         bool SetPlayState(AmUInt32 id, AmUInt32 layer, PlayStateFlag flag);
 

--- a/src/Mixer/RealChannel.cpp
+++ b/src/Mixer/RealChannel.cpp
@@ -333,6 +333,58 @@ namespace SparkyStudios::Audio::Amplitude
         return success;
     }
 
+    bool RealChannel::Seek(AmTime position)
+    {
+        AMPLITUDE_ASSERT(Valid());
+
+        if (_layers.size() != 1)
+        {
+            amLogWarning("Cannot seek real channel " AM_ID_CHAR_FMT ". Seeking is only supported on single-layer channels.", _channelId);
+            return false;
+        }
+
+        auto& data = _layers.begin()->second;
+        if (data.mixerLayerId == kAmInvalidObjectId || data.soundInstance == nullptr)
+            return false;
+
+        const auto* soundData = static_cast<const SoundData*>(data.soundInstance->GetUserData());
+        if (soundData == nullptr || soundData->format.GetSampleRate() == 0)
+            return false;
+
+        const AmTime clampedPosition = std::max<AmTime>(position, 0.0);
+        const AmUInt64 cursor = static_cast<AmUInt64>(clampedPosition * static_cast<AmTime>(soundData->format.GetSampleRate()) / kAmSecond);
+
+        return _mixer->SetCursor(_channelId, data.mixerLayerId, cursor);
+    }
+
+    AmTime RealChannel::GetPlaybackPosition() const
+    {
+        AMPLITUDE_ASSERT(Valid());
+
+        if (_layers.size() != 1)
+        {
+            amLogWarning(
+                "Cannot query playback position for real channel " AM_ID_CHAR_FMT
+                ". Playback position is only supported on single-layer channels.",
+                _channelId);
+            return 0.0;
+        }
+
+        const auto& data = _layers.begin()->second;
+        if (data.mixerLayerId == kAmInvalidObjectId || data.soundInstance == nullptr)
+            return 0.0;
+
+        const auto* soundData = static_cast<const SoundData*>(data.soundInstance->GetUserData());
+        if (soundData == nullptr || soundData->format.GetSampleRate() == 0)
+            return 0.0;
+
+        AmUInt64 cursor = 0;
+        if (!_mixer->GetCursor(_channelId, data.mixerLayerId, cursor))
+            return 0.0;
+
+        return static_cast<AmTime>(cursor) * kAmSecond / static_cast<AmTime>(soundData->format.GetSampleRate());
+    }
+
     void RealChannel::SetPitch(AmReal32 pitch)
     {
         AMPLITUDE_ASSERT(Valid());

--- a/src/Mixer/RealChannel.cpp
+++ b/src/Mixer/RealChannel.cpp
@@ -343,7 +343,7 @@ namespace SparkyStudios::Audio::Amplitude
             return false;
         }
 
-        auto& data = _layers.begin()->second;
+        const auto& data = _layers.begin()->second;
         if (data.mixerLayerId == kAmInvalidObjectId || data.soundInstance == nullptr)
             return false;
 
@@ -354,7 +354,17 @@ namespace SparkyStudios::Audio::Amplitude
         const AmTime clampedPosition = std::max<AmTime>(position, 0.0);
         const AmUInt64 cursor = static_cast<AmUInt64>(clampedPosition * static_cast<AmTime>(soundData->format.GetSampleRate()) / kAmSecond);
 
-        return _mixer->SetCursor(_channelId, data.mixerLayerId, cursor);
+        const AmUInt32 mixerLayerId = data.mixerLayerId;
+        const MixerCommandCallback callback = [this, mixerLayerId, cursor]() -> bool
+        {
+            if (!_mixer->SetCursor(_channelId, mixerLayerId, cursor))
+                return false;
+
+            return _mixer->ResetLayerState(_channelId, mixerLayerId);
+        };
+
+        _mixer->PushCommand({ callback });
+        return true;
     }
 
     AmTime RealChannel::GetPlaybackPosition() const

--- a/src/Mixer/RealChannel.h
+++ b/src/Mixer/RealChannel.h
@@ -92,8 +92,7 @@ namespace SparkyStudios::Audio::Amplitude
         /**
          * @brief Seek the real channel to the given playback position.
          *
-         * @param position The playback
-         * position in milliseconds.
+         * @param position The playback position in milliseconds.
          *
          * @return @c true on success, @c false otherwise.
          */
@@ -102,8 +101,7 @@ namespace SparkyStudios::Audio::Amplitude
         /**
          * @brief Get the current playback position.
          *
-         * @return The current playback position in
-         * milliseconds.
+         * @return The current playback position in milliseconds.
          */
         [[nodiscard]] AmTime GetPlaybackPosition() const;
 

--- a/src/Mixer/RealChannel.h
+++ b/src/Mixer/RealChannel.h
@@ -89,6 +89,24 @@ namespace SparkyStudios::Audio::Amplitude
         bool Resume(AmUInt32 layer);
         bool Resume();
 
+        /**
+         * @brief Seek the real channel to the given playback position.
+         *
+         * @param position The playback
+         * position in milliseconds.
+         *
+         * @return @c true on success, @c false otherwise.
+         */
+        bool Seek(AmTime position);
+
+        /**
+         * @brief Get the current playback position.
+         *
+         * @return The current playback position in
+         * milliseconds.
+         */
+        [[nodiscard]] AmTime GetPlaybackPosition() const;
+
         void Destroy(AmUInt32 layer = kAmInvalidObjectId);
 
         /**
@@ -211,7 +229,7 @@ namespace SparkyStudios::Audio::Amplitude
             bool isStream = false;                      ///< Whether this layer is streaming audio
             bool isLoop = false;                        ///< Whether this layer should loop
             AmReal32 gain = 1.0f;                       ///< Per-layer gain value (defaults to unity)
-            SoundInstance* soundInstance = nullptr;      ///< The sound instance playing on this layer
+            SoundInstance* soundInstance = nullptr;     ///< The sound instance playing on this layer
         };
 
         [[nodiscard]] AmUInt32 FindFreeLayer(AmUInt32 layerIndex = 0) const;

--- a/tests/core_channel_instances/test_blended_mode_can_seek_shared_cursor.cpp
+++ b/tests/core_channel_instances/test_blended_mode_can_seek_shared_cursor.cpp
@@ -41,6 +41,7 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             AM_EXPECT(channel.GetInstancingMode() == eChannelInstanceMode_Blended);
 
             constexpr AmTime seekPosition = 1000.0;
+            AM_EXPECT(channel.GetPlaybackPosition() < seekPosition);
             AM_EXPECT(channel.SetPlaybackPosition(seekPosition));
             amEngine->WaitUntilFrames(4);
 

--- a/tests/core_channel_instances/test_blended_mode_can_seek_shared_cursor.cpp
+++ b/tests/core_channel_instances/test_blended_mode_can_seek_shared_cursor.cpp
@@ -40,9 +40,12 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             AM_EXPECT(channel.GetInstanceCount() == 2);
             AM_EXPECT(channel.GetInstancingMode() == eChannelInstanceMode_Blended);
 
-            constexpr AmTime seekPosition = 15.0;
-            AM_EXPECT(channel.Seek(seekPosition));
-            ExpectDoubleNear(seekPosition, channel.GetPlaybackPosition(), 5.0, __FILE__, __LINE__);
+            constexpr AmTime seekPosition = 1000.0;
+            AM_EXPECT(channel.SetPlaybackPosition(seekPosition));
+            amEngine->WaitUntilFrames(4);
+
+            const AmTime playbackPosition = channel.GetPlaybackPosition();
+            AM_EXPECT(playbackPosition >= seekPosition);
 
             channel.Stop(0);
         }

--- a/tests/core_channel_instances/test_blended_mode_can_seek_shared_cursor.cpp
+++ b/tests/core_channel_instances/test_blended_mode_can_seek_shared_cursor.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+#include "TestRegistry.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    AM_TEST_CASE(EngineTestCase, core_channel_instances, blended_mode_can_seek_shared_cursor)
+    {
+    public:
+        void Run() override
+        {
+            SoundHandle sound = amEngine->GetSoundHandle("test_sound_01");
+
+            Channel channel = amEngine->Play(sound);
+            amEngine->WaitUntilFrames(2);
+
+            AM_EXPECT(channel.Valid());
+
+            channel.EnableInstancing(eChannelInstanceMode_Blended);
+            AM_UNUSED(channel.AddInstance({ 100.0f, 0.0f, 50.0f }));
+            AM_UNUSED(channel.AddInstance({ 120.0f, 0.0f, 80.0f }));
+
+            AM_EXPECT(channel.GetInstanceCount() == 2);
+            AM_EXPECT(channel.GetInstancingMode() == eChannelInstanceMode_Blended);
+
+            constexpr AmTime seekPosition = 15.0;
+            AM_EXPECT(channel.Seek(seekPosition));
+            ExpectDoubleNear(seekPosition, channel.GetPlaybackPosition(), 5.0, __FILE__, __LINE__);
+
+            channel.Stop(0);
+        }
+    };
+
+    AM_REGISTER_TEST(core_channel_instances, blended_mode_can_seek_shared_cursor);
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_channel_instances/test_separate_mode_rejects_channel_seek.cpp
+++ b/tests/core_channel_instances/test_separate_mode_rejects_channel_seek.cpp
@@ -36,7 +36,7 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             channel.EnableInstancing(eChannelInstanceMode_Separate);
             AM_UNUSED(channel.AddInstance({ 100.0f, 0.0f, 50.0f }));
 
-            AM_EXPECT_NOT(channel.Seek(10.0));
+            AM_EXPECT_NOT(channel.SetPlaybackPosition(10.0));
             AM_EXPECT_EQ(channel.GetPlaybackPosition(), 0.0);
 
             channel.Stop(0);

--- a/tests/core_channel_instances/test_separate_mode_rejects_channel_seek.cpp
+++ b/tests/core_channel_instances/test_separate_mode_rejects_channel_seek.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+#include "TestRegistry.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    AM_TEST_CASE(EngineTestCase, core_channel_instances, separate_mode_rejects_channel_seek)
+    {
+    public:
+        void Run() override
+        {
+            SoundHandle sound = amEngine->GetSoundHandle("test_sound_01");
+
+            Channel channel = amEngine->Play(sound);
+            amEngine->WaitUntilFrames(2);
+
+            AM_EXPECT(channel.Valid());
+
+            channel.EnableInstancing(eChannelInstanceMode_Separate);
+            AM_UNUSED(channel.AddInstance({ 100.0f, 0.0f, 50.0f }));
+
+            AM_EXPECT_NOT(channel.Seek(10.0));
+            AM_EXPECT_EQ(channel.GetPlaybackPosition(), 0.0);
+
+            channel.Stop(0);
+        }
+    };
+
+    AM_REGISTER_TEST(core_channel_instances, separate_mode_rejects_channel_seek);
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_engine/test_can_play_collection_using_handle.cpp
+++ b/tests/core_engine/test_can_play_collection_using_handle.cpp
@@ -33,6 +33,8 @@ namespace SparkyStudios::Audio::Amplitude::Tests
 
             AM_EXPECT(channel.Valid());
             AM_EXPECT(channel.Playing());
+
+            channel.Stop(0);
         }
     };
 

--- a/tests/core_engine/test_can_play_sound_using_name.cpp
+++ b/tests/core_engine/test_can_play_sound_using_name.cpp
@@ -26,11 +26,13 @@ namespace SparkyStudios::Audio::Amplitude::Tests
     public:
         void Run() override
         {
-            Channel channel = amEngine->Play("test_sound_03");
+            Channel channel = amEngine->Play("test_sound_01");
             amEngine->WaitUntilFrames(2); // Playing is done in the next frame
 
             AM_EXPECT(channel.Valid());
             AM_EXPECT(channel.Playing());
+
+            channel.Stop(0);
         }
     };
 

--- a/tests/core_engine/test_channel_can_seek.cpp
+++ b/tests/core_engine/test_channel_can_seek.cpp
@@ -34,9 +34,12 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             AM_EXPECT(channel.Valid());
             AM_EXPECT(channel.Playing());
 
-            constexpr AmTime seekPosition = 10.0;
-            AM_EXPECT(channel.Seek(seekPosition));
-            ExpectDoubleNear(seekPosition, channel.GetPlaybackPosition(), 5.0, __FILE__, __LINE__);
+            constexpr AmTime seekPosition = 1000.0;
+            AM_EXPECT(channel.SetPlaybackPosition(seekPosition));
+            amEngine->WaitUntilFrames(4);
+
+            const AmTime playbackPosition = channel.GetPlaybackPosition();
+            AM_EXPECT(playbackPosition >= seekPosition);
 
             channel.Stop(0);
         }

--- a/tests/core_engine/test_channel_can_seek.cpp
+++ b/tests/core_engine/test_channel_can_seek.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+#include "TestRegistry.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    AM_TEST_CASE(EngineTestCase, core_engine, channel_can_seek)
+    {
+    public:
+        void Run() override
+        {
+            SoundHandle sound = amEngine->GetSoundHandle("test_sound_01");
+
+            Channel channel = amEngine->Play(sound);
+            amEngine->WaitUntilFrames(2);
+
+            AM_EXPECT(channel.Valid());
+            AM_EXPECT(channel.Playing());
+
+            constexpr AmTime seekPosition = 10.0;
+            AM_EXPECT(channel.Seek(seekPosition));
+            ExpectDoubleNear(seekPosition, channel.GetPlaybackPosition(), 5.0, __FILE__, __LINE__);
+
+            channel.Stop(0);
+        }
+    };
+
+    AM_REGISTER_TEST(core_engine, channel_can_seek);
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_engine/test_channel_can_seek.cpp
+++ b/tests/core_engine/test_channel_can_seek.cpp
@@ -35,6 +35,7 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             AM_EXPECT(channel.Playing());
 
             constexpr AmTime seekPosition = 1000.0;
+            AM_EXPECT(channel.GetPlaybackPosition() < seekPosition);
             AM_EXPECT(channel.SetPlaybackPosition(seekPosition));
             amEngine->WaitUntilFrames(4);
 

--- a/tests/core_engine/test_channel_can_seek_while_paused.cpp
+++ b/tests/core_engine/test_channel_can_seek_while_paused.cpp
@@ -38,7 +38,8 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             AM_EXPECT_EQ(channel.GetPlaybackState(), eChannelPlaybackState_Paused);
 
             constexpr AmTime seekPosition = 25.0;
-            AM_EXPECT(channel.Seek(seekPosition));
+            AM_EXPECT(channel.SetPlaybackPosition(seekPosition));
+            amEngine->WaitUntilFrames(4);
             ExpectDoubleNear(seekPosition, channel.GetPlaybackPosition(), 5.0, __FILE__, __LINE__);
 
             channel.Resume(0);

--- a/tests/core_engine/test_channel_can_seek_while_paused.cpp
+++ b/tests/core_engine/test_channel_can_seek_while_paused.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+#include "TestRegistry.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    AM_TEST_CASE(EngineTestCase, core_engine, channel_can_seek_while_paused)
+    {
+    public:
+        void Run() override
+        {
+            SoundHandle sound = amEngine->GetSoundHandle("test_sound_01");
+
+            Channel channel = amEngine->Play(sound);
+            amEngine->WaitUntilFrames(2);
+
+            AM_EXPECT(channel.Valid());
+            AM_EXPECT(channel.Playing());
+
+            channel.Pause(0);
+            AM_EXPECT_EQ(channel.GetPlaybackState(), eChannelPlaybackState_Paused);
+
+            constexpr AmTime seekPosition = 25.0;
+            AM_EXPECT(channel.Seek(seekPosition));
+            ExpectDoubleNear(seekPosition, channel.GetPlaybackPosition(), 5.0, __FILE__, __LINE__);
+
+            channel.Resume(0);
+            AM_EXPECT_EQ(channel.GetPlaybackState(), eChannelPlaybackState_Playing);
+            AM_EXPECT(channel.Playing());
+
+            channel.Stop(0);
+        }
+    };
+
+    AM_REGISTER_TEST(core_engine, channel_can_seek_while_paused);
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_engine/test_channel_can_seek_while_paused.cpp
+++ b/tests/core_engine/test_channel_can_seek_while_paused.cpp
@@ -37,7 +37,8 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             channel.Pause(0);
             AM_EXPECT_EQ(channel.GetPlaybackState(), eChannelPlaybackState_Paused);
 
-            constexpr AmTime seekPosition = 25.0;
+            constexpr AmTime seekPosition = 1000.0;
+            AM_EXPECT(channel.GetPlaybackPosition() < seekPosition);
             AM_EXPECT(channel.SetPlaybackPosition(seekPosition));
             amEngine->WaitUntilFrames(4);
             ExpectDoubleNear(seekPosition, channel.GetPlaybackPosition(), 5.0, __FILE__, __LINE__);

--- a/tests/core_engine/test_channel_clamps_negative_playback_position.cpp
+++ b/tests/core_engine/test_channel_clamps_negative_playback_position.cpp
@@ -21,7 +21,7 @@ using namespace SparkyStudios::Audio::Amplitude;
 
 namespace SparkyStudios::Audio::Amplitude::Tests
 {
-    AM_TEST_CASE(EngineTestCase, core_engine, channel_playback_position_advances)
+    AM_TEST_CASE(EngineTestCase, core_engine, channel_clamps_negative_playback_position)
     {
     public:
         void Run() override
@@ -32,20 +32,18 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             amEngine->WaitUntilFrames(2);
 
             AM_EXPECT(channel.Valid());
+            AM_EXPECT(channel.Playing());
 
-            const AmTime firstPosition = channel.GetPlaybackPosition();
-            AmTime secondPosition = firstPosition;
-            for (AmUInt32 attempts = 0; attempts < 30 && secondPosition <= firstPosition; ++attempts)
-            {
-                amEngine->WaitUntilFrames(1);
-                secondPosition = channel.GetPlaybackPosition();
-            }
+            channel.Pause(0);
+            AM_EXPECT_EQ(channel.GetPlaybackState(), eChannelPlaybackState_Paused);
 
-            AM_EXPECT(secondPosition > firstPosition);
+            AM_EXPECT(channel.SetPlaybackPosition(-100.0));
+            amEngine->WaitUntilFrames(4);
+            ExpectDoubleNear(0.0, channel.GetPlaybackPosition(), 5.0, __FILE__, __LINE__);
 
             channel.Stop(0);
         }
     };
 
-    AM_REGISTER_TEST(core_engine, channel_playback_position_advances);
+    AM_REGISTER_TEST(core_engine, channel_clamps_negative_playback_position);
 } // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_engine/test_channel_playback_position_advances.cpp
+++ b/tests/core_engine/test_channel_playback_position_advances.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "EngineTestCase.h"
+#include "TestRegistry.h"
+
+using namespace SparkyStudios::Audio::Amplitude;
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    AM_TEST_CASE(EngineTestCase, core_engine, channel_playback_position_advances)
+    {
+    public:
+        void Run() override
+        {
+            SoundHandle sound = amEngine->GetSoundHandle("test_sound_01");
+
+            Channel channel = amEngine->Play(sound);
+            amEngine->WaitUntilFrames(2);
+
+            AM_EXPECT(channel.Valid());
+
+            const AmTime firstPosition = channel.GetPlaybackPosition();
+            amEngine->WaitUntilFrames(4);
+            const AmTime secondPosition = channel.GetPlaybackPosition();
+
+            AM_EXPECT(secondPosition > firstPosition);
+
+            channel.Stop(0);
+        }
+    };
+
+    AM_REGISTER_TEST(core_engine, channel_playback_position_advances);
+} // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_engine/test_invalid_channel_state_rejects_playback_position.cpp
+++ b/tests/core_engine/test_invalid_channel_state_rejects_playback_position.cpp
@@ -14,6 +14,8 @@
 
 #include <SparkyStudios/Audio/Amplitude/Amplitude.h>
 
+#include <Core/Playback/ChannelInternalState.h>
+
 #include "EngineTestCase.h"
 #include "TestRegistry.h"
 
@@ -21,31 +23,17 @@ using namespace SparkyStudios::Audio::Amplitude;
 
 namespace SparkyStudios::Audio::Amplitude::Tests
 {
-    AM_TEST_CASE(EngineTestCase, core_engine, channel_playback_position_advances)
+    AM_TEST_CASE(EngineTestCase, core_engine, invalid_channel_state_rejects_playback_position)
     {
     public:
         void Run() override
         {
-            SoundHandle sound = amEngine->GetSoundHandle("test_sound_01");
+            ChannelInternalState uninitializedState;
 
-            Channel channel = amEngine->Play(sound);
-            amEngine->WaitUntilFrames(2);
-
-            AM_EXPECT(channel.Valid());
-
-            const AmTime firstPosition = channel.GetPlaybackPosition();
-            AmTime secondPosition = firstPosition;
-            for (AmUInt32 attempts = 0; attempts < 30 && secondPosition <= firstPosition; ++attempts)
-            {
-                amEngine->WaitUntilFrames(1);
-                secondPosition = channel.GetPlaybackPosition();
-            }
-
-            AM_EXPECT(secondPosition > firstPosition);
-
-            channel.Stop(0);
+            AM_EXPECT_NOT(uninitializedState.SetPlaybackPosition(10.0));
+            AM_EXPECT_EQ(uninitializedState.GetPlaybackPosition(), 0.0);
         }
     };
 
-    AM_REGISTER_TEST(core_engine, channel_playback_position_advances);
+    AM_REGISTER_TEST(core_engine, invalid_channel_state_rejects_playback_position);
 } // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_engine/test_mixer_rejects_invalid_playback_cursor_operations.cpp
+++ b/tests/core_engine/test_mixer_rejects_invalid_playback_cursor_operations.cpp
@@ -14,6 +14,9 @@
 
 #include <SparkyStudios/Audio/Amplitude/Amplitude.h>
 
+#include <Core/Engine.h>
+#include <Mixer/Amplimix.h>
+
 #include "EngineTestCase.h"
 #include "TestRegistry.h"
 
@@ -21,31 +24,19 @@ using namespace SparkyStudios::Audio::Amplitude;
 
 namespace SparkyStudios::Audio::Amplitude::Tests
 {
-    AM_TEST_CASE(EngineTestCase, core_engine, channel_playback_position_advances)
+    AM_TEST_CASE(EngineTestCase, core_engine, mixer_rejects_invalid_playback_cursor_operations)
     {
     public:
         void Run() override
         {
-            SoundHandle sound = amEngine->GetSoundHandle("test_sound_01");
+            AmplimixImpl& mixer = amEngine->GetState()->mixer;
+            AmUInt64 cursor = 0;
 
-            Channel channel = amEngine->Play(sound);
-            amEngine->WaitUntilFrames(2);
-
-            AM_EXPECT(channel.Valid());
-
-            const AmTime firstPosition = channel.GetPlaybackPosition();
-            AmTime secondPosition = firstPosition;
-            for (AmUInt32 attempts = 0; attempts < 30 && secondPosition <= firstPosition; ++attempts)
-            {
-                amEngine->WaitUntilFrames(1);
-                secondPosition = channel.GetPlaybackPosition();
-            }
-
-            AM_EXPECT(secondPosition > firstPosition);
-
-            channel.Stop(0);
+            AM_EXPECT_NOT(mixer.SetCursor(kAmInvalidObjectId, 0, 10));
+            AM_EXPECT_NOT(mixer.GetCursor(kAmInvalidObjectId, 0, cursor));
+            AM_EXPECT_NOT(mixer.ResetLayerState(kAmInvalidObjectId, 0));
         }
     };
 
-    AM_REGISTER_TEST(core_engine, channel_playback_position_advances);
+    AM_REGISTER_TEST(core_engine, mixer_rejects_invalid_playback_cursor_operations);
 } // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/core_engine/test_stale_channel_rejects_playback_position.cpp
+++ b/tests/core_engine/test_stale_channel_rejects_playback_position.cpp
@@ -14,6 +14,8 @@
 
 #include <SparkyStudios/Audio/Amplitude/Amplitude.h>
 
+#include <Core/Playback/ChannelInternalState.h>
+
 #include "EngineTestCase.h"
 #include "TestRegistry.h"
 
@@ -21,7 +23,7 @@ using namespace SparkyStudios::Audio::Amplitude;
 
 namespace SparkyStudios::Audio::Amplitude::Tests
 {
-    AM_TEST_CASE(EngineTestCase, core_engine, channel_playback_position_advances)
+    AM_TEST_CASE(EngineTestCase, core_engine, stale_channel_rejects_playback_position)
     {
     public:
         void Run() override
@@ -32,20 +34,19 @@ namespace SparkyStudios::Audio::Amplitude::Tests
             amEngine->WaitUntilFrames(2);
 
             AM_EXPECT(channel.Valid());
+            AM_EXPECT(channel.Playing());
 
-            const AmTime firstPosition = channel.GetPlaybackPosition();
-            AmTime secondPosition = firstPosition;
-            for (AmUInt32 attempts = 0; attempts < 30 && secondPosition <= firstPosition; ++attempts)
-            {
-                amEngine->WaitUntilFrames(1);
-                secondPosition = channel.GetPlaybackPosition();
-            }
+            ChannelInternalState* state = channel.GetState();
+            const AmUInt64 validStateId = state->GetChannelStateId();
 
-            AM_EXPECT(secondPosition > firstPosition);
+            state->SetChannelStateId(validStateId + 1);
+            AM_EXPECT_NOT(channel.SetPlaybackPosition(10.0));
+            AM_EXPECT_EQ(channel.GetPlaybackPosition(), 0.0);
 
+            state->SetChannelStateId(validStateId);
             channel.Stop(0);
         }
     };
 
-    AM_REGISTER_TEST(core_engine, channel_playback_position_advances);
+    AM_REGISTER_TEST(core_engine, stale_channel_rejects_playback_position);
 } // namespace SparkyStudios::Audio::Amplitude::Tests

--- a/tests/dsp_utilities/test_audio_converter_reset_preserves_configuration.cpp
+++ b/tests/dsp_utilities/test_audio_converter_reset_preserves_configuration.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026-present Sparky Studios. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <SparkyStudios/Audio/Amplitude/Amplitude.h>
+
+#include "DSPTestCase.h"
+#include "TestRegistry.h"
+
+namespace SparkyStudios::Audio::Amplitude::Tests
+{
+    AM_TEST_CASE(DSPTestCase, dsp_utilities, audio_converter_reset_preserves_configuration)
+    {
+    public:
+        void Run() override
+        {
+            AudioConverter converter;
+
+            AudioConverter::Settings settings;
+            settings.m_sourceSampleRate = 48000;
+            settings.m_targetSampleRate = 48000;
+            settings.m_sourceChannelCount = 1;
+            settings.m_targetChannelCount = 2;
+
+            AM_EXPECT(converter.Configure(settings));
+            converter.Reset();
+
+            constexpr AmUInt64 frameCount = 16;
+            AudioBuffer input(frameCount, 1);
+            AudioBuffer output(frameCount, 2);
+
+            for (AmUInt64 i = 0; i < frameCount; ++i)
+                input[0][i] = 1.0f;
+
+            AmUInt64 inputFrames = frameCount;
+            AmUInt64 outputFrames = frameCount;
+            converter.Process(input, inputFrames, output, outputFrames);
+
+            AM_EXPECT(EnsureHasNonZeroOutput(output));
+            AM_EXPECT(output.GetChannelCount() == 2);
+            AM_EXPECT(output[1][0] > 0.0f);
+        }
+    };
+
+    AM_REGISTER_TEST(dsp_utilities, audio_converter_reset_preserves_configuration);
+} // namespace SparkyStudios::Audio::Amplitude::Tests


### PR DESCRIPTION
Add public Channel APIs for setting and querying playback position:
SetPlaybackPosition(AmTime) and GetPlaybackPosition(). The public API uses
AmTime milliseconds, while the mixer continues to use frame-based cursors
internally.

Keep v1 behavior scoped to single-layer channels and blended instancing.
Separate instancing remains unsupported for channel-level playback-position
control and is rejected with a warning. The internal RealChannel::Seek()
path is retained as the implementation detail behind the public API.

Defer playback cursor changes through the Amplimix command queue so cursor
updates run after the current mix iteration. Add AmplimixImpl::ResetLayerState()
to reset the layer data converter and pipeline through ResetPipeline() after
a cursor change, avoiding direct mixer-state mutation during audio rendering.

Add and update tests for normal playback-position changes, paused changes,
playback-position advancement, blended instancing, separate-instancing
rejection, negative position clamping, invalid/stale channel state rejection,
invalid mixer cursor operations, and CI-stable playback cleanup.

This should address https://github.com/AmplitudeAudio/sdk/issues/14
